### PR TITLE
all to all2

### DIFF
--- a/R/f.npafp.rate.01.R
+++ b/R/f.npafp.rate.01.R
@@ -7,7 +7,7 @@
 #' @import lubridate
 #' @import tibble
 #' @param afp.data tibble: AFP data which includes GUID at a given spatial scale
-#' formated as "adm{0,1,2}guid, onset date as "date" and cdc.classification.all which includes
+#' formated as "adm{0,1,2}guid, onset date as "date" and cdc.classification.all2 which includes
 #' c("NPAFP", "PENDING", "LAB PENDING")
 #' @param pop.data tibble: Under 15 population data by a given spatial scale including
 #' "year", "adm{0,1,2}guid, "u15pop", and "{ctry/prov/dist}" as appropriate
@@ -31,7 +31,7 @@ f.npafp.rate.01 <- function(
     ){
 
   #file names
-  names.afp.ctry <- c("adm0guid", "date", "cdc.classification.all")
+  names.afp.ctry <- c("adm0guid", "date", "cdc.classification.all2")
   names.afp.prov <- c(names.afp.ctry, "adm1guid")
   names.afp.dist <- c(names.afp.prov, "adm2guid")
 
@@ -195,7 +195,7 @@ f.npafp.rate.01 <- function(
     npafp.data <- afp.data |>
       as_tibble() |>
       filter(
-        cdc.classification.all %in% c("NPAFP", "PENDING", "LAB PENDING")
+        cdc.classification.all2 %in% c("NPAFP", "PENDING", "LAB PENDING")
         ) |> # filter all AFP data such that only cases listed as NPAFP,
       # PENDING, or LAB PENDING are counted
       select(epid, date, ctry, adm0guid, prov, adm1guid, dist, adm2guid)
@@ -203,7 +203,7 @@ f.npafp.rate.01 <- function(
   }else{
     npafp.data <- afp.data |>
       as_tibble() |>
-      filter(cdc.classification.all == "NPAFP") |> # filter all AFP data such
+      filter(cdc.classification.all2 == "NPAFP") |> # filter all AFP data such
       # that only cases listed as NPAFP are counted
       select(epid, date, ctry, adm0guid, prov, adm1guid, dist, adm2guid)
     # Keep only the listed variables (removes all others)

--- a/R/f.stool.ad.01.R
+++ b/R/f.stool.ad.01.R
@@ -10,7 +10,7 @@
 #' @import lubridate
 #' @import tibble
 #' @param afp.data tibble: AFP data which includes GUID at a given spatial scale
-#' formatted as "adm{0,1,2}guid, onset date as "date" and cdc.classification.all
+#' formatted as "adm{0,1,2}guid, onset date as "date" and cdc.classification.all2
 #' which includes "NOT-AFP"
 #' @param admin.data tibble: Full list of country administrative units by a given
 #' spatial scale including "year", "adm{0,1,2}guid, and "{ctry/prov/dist}"
@@ -36,7 +36,7 @@ f.stool.ad.01 <- function(
     ){
 
   #file names
-  names.afp.ctry <- c("adm0guid", "date", "cdc.classification.all")
+  names.afp.ctry <- c("adm0guid", "date", "cdc.classification.all2")
   names.afp.prov <- c(names.afp.ctry, "adm1guid")
   names.afp.dist <- c(names.afp.prov, "adm2guid")
 
@@ -233,7 +233,7 @@ f.stool.ad.01 <- function(
 
 stool.data <- afp.data |>
   as_tibble() |>
-  filter(cdc.classification.all != "NOT-AFP") |>
+  filter(cdc.classification.all2 != "NOT-AFP") |>
   mutate(adequacy.final = case_when(#Conditions for Bad Data
     bad.stool1 == "data entry error" |
       bad.stool1 == "date before onset" |
@@ -266,7 +266,7 @@ stool.data <- afp.data |>
   )) |>
     mutate(year = year(date)) |>
     select(year, adm0guid, adm1guid, adm2guid,
-           adequacy.final, cdc.classification.all)
+           adequacy.final, cdc.classification.all2)
 
   stool.data <- full_join( # Merge stool data with days in year
     stool.data, year.data,

--- a/R/f.timely.detection.01.R
+++ b/R/f.timely.detection.01.R
@@ -97,8 +97,8 @@ f.timely.detection.01 <- function(
   #1. AFP detection
   afp.pos.detect.01 <- afp.data %>%
     ungroup() %>%
-    filter(!cdc.classification.all %in% c("COMPATIBLE" ,"NPAFP", "PENDING", "UNKNOWN", "VAPP", "LAB PENDING")) %>%
-    select(epid, ctry, year, cdc.classification.all, date, datenotificationtohq) %>%
+    filter(!cdc.classification.all2 %in% c("COMPATIBLE" ,"NPAFP", "PENDING", "UNKNOWN", "VAPP", "LAB PENDING")) %>%
+    select(epid, ctry, year, cdc.classification.all2, date, datenotificationtohq) %>%
     mutate(
       datenotifytohq = dmy(datenotificationtohq),
       ontonothq = as.numeric(datenotifytohq - date)

--- a/man/f.npafp.rate.01.Rd
+++ b/man/f.npafp.rate.01.Rd
@@ -17,7 +17,7 @@ f.npafp.rate.01(
 }
 \arguments{
 \item{afp.data}{tibble: AFP data which includes GUID at a given spatial scale
-formated as "adm{0,1,2}guid, onset date as "date" and cdc.classification.all which includes
+formated as "adm{0,1,2}guid, onset date as "date" and cdc.classification.all2 which includes
 c("NPAFP", "PENDING", "LAB PENDING")}
 
 \item{pop.data}{tibble: Under 15 population data by a given spatial scale including

--- a/man/f.stool.ad.01.Rd
+++ b/man/f.stool.ad.01.Rd
@@ -17,7 +17,7 @@ f.stool.ad.01(
 }
 \arguments{
 \item{afp.data}{tibble: AFP data which includes GUID at a given spatial scale
-formatted as "adm{0,1,2}guid, onset date as "date" and cdc.classification.all
+formatted as "adm{0,1,2}guid, onset date as "date" and cdc.classification.all2
 which includes "NOT-AFP"}
 
 \item{admin.data}{tibble: Full list of country administrative units by a given


### PR DESCRIPTION
These functions previously used `cdc.classification.all`. Changed to `cdc.classification.all2`.