### PR TITLE
71 remove spatial requirement extract_country_data()

### DIFF
--- a/R/dal.R
+++ b/R/dal.R
@@ -789,7 +789,7 @@ extract_country_data <- function(
         return()
       }
 
-      chosen.country <- as.integer(stringr::str_trim(chosen.country))
+      chosen.country <- suppressWarnings(as.integer(stringr::str_trim(chosen.country)))
       if (is.na(chosen.country) | !(chosen.country %in% 1:length(ctrys))) {
         message("Invalid choice, please try again.")
         attempts <- attempts - 1
@@ -801,7 +801,6 @@ extract_country_data <- function(
         next
       } else {
         chosen.country <- ctrys[chosen.country]
-        print(chosen.country)
         response = F
       }
     }
@@ -809,9 +808,10 @@ extract_country_data <- function(
     chosen.country <- ctrys[1]
   }
 
-  .country <- ctrys[chosen.country] |> stringr::str_to_upper()
+  .country <- chosen.country |> stringr::str_to_upper()
   ctry.data <- list()
   steps <- 1
+
   if (!is.null(.raw.data$global.ctry)) {
   cli::cli_process_start(paste0(steps,") Subsetting country spatial data\n"))
   ctry.data$ctry <- .raw.data$global.ctry |>
@@ -957,7 +957,26 @@ extract_country_data <- function(
            prov = ADM1_NAME,
            dist = ADM2_NAME,
            u15pop,
-           adm2guid)
+           adm2guid,
+           datasource)
+
+  ctry.data$ctry.pop <- .raw.data$ctry.pop |>
+    dplyr::filter(ADM0_NAME == .country) |>
+    dplyr::select(year,
+                  ctry = ADM0_NAME,
+                  u15pop,
+                  adm0guid,
+                  datasource)
+
+  ctry.data$prov.pop <- .raw.data$prov.pop |>
+    dplyr::filter(ADM0_NAME == .country) |>
+    dplyr::mutate(ADM0_NAME = .country) |>
+    dplyr::select(year,
+                  ctry = ADM0_NAME,
+                  prov = ADM1_NAME,
+                  u15pop = u15pop.prov,
+                  adm1guid,
+                  datasource)
 
   cli::cli_process_done()
   steps <- steps + 1

--- a/R/dal.R
+++ b/R/dal.R
@@ -745,10 +745,9 @@ get_all_polio_data <- function(
 #' Extract country specific information from raw polio data
 #'
 #' @description Extract country specific data from the CDC generated "raw.data" file from `get_all_polio_data`.
-#' The input will also need spatial data attached. Outputs list of country specific data and spatial objects.
+#' Outputs list of country specific data and spatial objects (if applicable).
 #' @import cli dplyr sf stringr
-#' @param .raw.data list: list of raw data sources that is output from `get_all_polio_data`. This raw.data file will also
-#' need to include all spatial data.
+#' @param .raw.data list: list of raw data sources that is output from `get_all_polio_data`.
 #' @param .country str: a country name of interest
 #' @return list with country specific objects
 #' @export

--- a/man/extract_country_data.Rd
+++ b/man/extract_country_data.Rd
@@ -9,13 +9,12 @@ extract_country_data(.country, .raw.data = raw.data)
 \arguments{
 \item{.country}{str: a country name of interest}
 
-\item{.raw.data}{list: list of raw data sources that is output from \code{get_all_polio_data}. This raw.data file will also
-need to include all spatial data.}
+\item{.raw.data}{list: list of raw data sources that is output from \code{get_all_polio_data}.}
 }
 \value{
 list with country specific objects
 }
 \description{
 Extract country specific data from the CDC generated "raw.data" file from \code{get_all_polio_data}.
-The input will also need spatial data attached. Outputs list of country specific data and spatial objects.
+Outputs list of country specific data and spatial objects (if applicable).
 }


### PR DESCRIPTION
Introduced several features to `extract_country_data()`:

1. Handling of spatial file errors are more explicit and programmatic. This is resolves issue #73.
2. Removed requirement of a `.raw.data` to contain spatial files before `extract_country_data()` can run. This resolves issue #71.
3. Included prov and country population datasets to the output of `extract_country_data()`. This resolves issue #69. 