### PR TITLE
🐛 f.stool.ad.01() NA for geography without AFP cases

### DIFF
--- a/R/f.stool.ad.01.R
+++ b/R/f.stool.ad.01.R
@@ -835,5 +835,9 @@ stool.data <- afp.data |>
 
     }
   }
+
+  int.data <- int.data |>
+    mutate(per.stool.ad = if_else(afp.cases == 0, NA, per.stool.ad))
+
   return(int.data)
 }


### PR DESCRIPTION
those without AFP cases should not have a stool adequacy of 0