### PR TITLE
❇️ additional subinterval data calculated for WHO lab data

### DIFF
--- a/R/dr.afp.functions.R
+++ b/R/dr.afp.functions.R
@@ -546,22 +546,22 @@ generate_int_data <- function(ctry.data, start_date, end_date, spatial.scale, la
   int.data <- switch(spatial.scale,
     "ctry" = {
       int.data <- int.data |>
-        tidyr::pivot_longer(!c(.data$epid, .data$year, .data$adm0guid, .data$ctry),
+        tidyr::pivot_longer(!c(epid, year, adm0guid, ctry),
           names_to = "type",
           values_to = "value"
         ) |>
         dplyr::group_by(year, type, adm0guid, ctry) |>
-        dplyr::summarize(medi = median(value, na.rm = T), freq =dplyr::n())
+        dplyr::summarize(medi = median(value, na.rm = T), freq = n())
     },
     "prov" = {
       int.data <- int.data |>
         tidyr::pivot_longer(
-          !c(.data$epid, .data$year, .data$adm0guid, .data$adm1guid, .data$prov, .data$ctry),
+          !c(epid, year, adm0guid, adm1guid, prov, ctry),
           names_to = "type",
           values_to = "value"
         ) %>%
         dplyr::group_by(year, type, adm1guid, prov, ctry) %>%
-        dplyr::summarize(medi = median(value, na.rm = T), freq =dplyr::n())
+        dplyr::summarize(medi = median(value, na.rm = T), freq = n())
     }
   )
 
@@ -595,6 +595,11 @@ generate_int_data <- function(ctry.data, start_date, end_date, spatial.scale, la
       "investtostool1" = "Case investigation to stool 1 collection",
       "stool1tostool2" = "Stool 1 collection to stool 2 collection",
       "days.collect.lab" = "Last stool collection to received in lab",
+      "days.coll.sent.field" = "Collection to sent from field",
+      "days.sent.field.rec.nat" = "Sent from field to received nat level",
+      "days.rec.nat.sent.lab" = "Received nat level to sent to lab",
+      "days.sent.lab.rec.lab" = "Sent to lab to received at lab",
+      "days.rec.lab.culture" = "Received at lab to culture results",
       "days.lab.culture" = "Stool received lab to final culture results",
       "days.seq.ship" = "Isolate received for sequencing to sequence results available",
       "days.lab.seq" = "Stool received in lab to sequence result",
@@ -613,9 +618,15 @@ generate_int_data <- function(ctry.data, start_date, end_date, spatial.scale, la
         "Case notification to investigation",
         "Case investigation to stool 1 collection",
         "Stool 1 collection to stool 2 collection",
-        "Last stool collection sent to lab",
-        "Last stool collection to received in lab",
-        "Stool received lab to final culture results"
+        # "Last stool collection sent to lab",
+        # "Last stool collection to received in lab",
+        # "Stool received lab to final culture results"
+
+        "Collection to sent from field",
+        "Sent from field to received nat level",
+        "Received nat level to sent to lab",
+        "Sent to lab to received at lab",
+        "Received at lab to culture results"
       )
     )
 

--- a/R/dr.figure.functions.R
+++ b/R/dr.figure.functions.R
@@ -41,7 +41,7 @@ generate_ctry_timeliness_graph <- function(int.data,
       guide = ggplot2::guide_legend(reverse = TRUE)
     ) +
     ggplot2::theme(
-      legend.position = "bottom",
+      legend.position = "right",
       legend.background = ggplot2::element_blank()
     )
 
@@ -97,12 +97,12 @@ generate_prov_timeliness_graph <- function(int.data,
         label = medi,
         group = forcats::fct_rev(type)
       ),
+      size = 3,
       position = ggplot2::position_stack(vjust = 0.5)
     ) +
     ggplot2::coord_flip() +
     ggplot2::ylab("Median Days") +
     ggplot2::xlab("Year of Paralysis Onset") +
-    # ggplot2::scale_y_continuous(breaks = seq(0, max(pretty(tot.time.p$tot))+1)) +
     ggplot2::scale_x_discrete() +
     ggplot2::ylab("Days") +
     ggplot2::xlab("Year") +
@@ -112,11 +112,11 @@ generate_prov_timeliness_graph <- function(int.data,
       guide = ggplot2::guide_legend(reverse = TRUE),
       drop = T
     ) +
-    ggplot2::facet_grid(prov ~ ., scales = "free_y", space = "free") +
+    ggplot2::facet_grid(prov ~ ., scales = "free_y", space = "free", switch = "y", labeller = label_wrap_gen(8)) +
     ggplot2::theme(
-      legend.position = "bottom",
+      legend.position = "right",
       legend.background = ggplot2::element_blank(),
-      strip.text.y = ggplot2::element_text(size = 5, angle = 0)
+      strip.text.y = ggplot2::element_text(size = 7, angle = 0)
     )
 
   ggplot2::ggsave(

--- a/R/dr.main.functions.R
+++ b/R/dr.main.functions.R
@@ -551,15 +551,20 @@ init_dr <-
     data_folder_files <- list.files(data_path)
 
 
-    if (!is.null(lab_data_path) & (stringr::str_detect(data_folder_files, "_lab_data_") |> sum()) == 0) {
-      cli::cli_process_start("Saving a copy of the lab data to the data folder.")
+    if (!is.null(lab_data_path)) {
       country_data$lab.data <- load_lab_data(lab_data_path)
-      dr_lab_data_path <- file.path(
-        data_path,
-        paste0(country_data$ctry$ISO_3_CODE, "_lab_data_", Sys.Date(), ".Rds")
-      )
-      saveRDS(country_data$lab.data, dr_lab_data_path)
-      Sys.setenv(DR_LAB_PATH = dr_lab_data_path)
+      # check if there is already a copy of lab data in the data folder
+      if ((stringr::str_detect(data_folder_files, "_lab_data_") |> sum()) == 0) {
+        cli::cli_process_start("Saving a copy of the lab data to the data folder.")
+        dr_lab_data_path <- file.path(
+          data_path,
+          paste0(country_data$ctry$ISO_3_CODE, "_lab_data_", Sys.Date(), ".Rds")
+        )
+        saveRDS(country_data$lab.data, dr_lab_data_path)
+        Sys.setenv(DR_LAB_PATH = dr_lab_data_path)
+      } else {
+        Sys.setenv(DR_LAB_PATH = lab_data_path)
+      }
     }
 
     # Attaching ISS data if available and creating a copy to data folder

--- a/R/f.color.schemes.R
+++ b/R/f.color.schemes.R
@@ -108,15 +108,22 @@ f.color.schemes <- function(type) {
         "No AFP cases" = "lightgrey",
         "Missing" = "grey34"
       ),
-    "timeliness.col.vars" =
-      c(
-      "Paralysis onset to notification" = "#377eb8",
-      "Case notification to investigation" = "#e41a1c",
-      "Case investigation to stool 1 collection" = "#4daf4a",
-      "Stool 1 collection to stool 2 collection" = "#984ea3",
+    timeliness.col.vars = c(
+      "Paralysis onset to notification" = "#a6cee3",
+      "Case notification to investigation" = "#1f78b4",
+      "Case investigation to stool 1 collection" = "#b2df8a",
+      "Stool 1 collection to stool 2 collection" = "#33a02c",
       "Last stool collection to received in lab" = "#ff7f00",
       "Last stool collection sent to lab" = "#ff7f00",
-      "Stool received lab to final culture results" = "#b55f04"
+
+      "Stool received lab to final culture results" = "#cab2d6",
+
+      "Collection to sent from field" = "#fb9a99",
+      "Sent from field to received nat level" = "#e31a1c",
+      "Received nat level to sent to lab" = "#fdbf6f",
+      "Sent to lab to received at lab" = "#ff7f00",
+      "Received at lab to culture results" = "#cab2d6"
     )
+
   )
 }

--- a/R/globals.R
+++ b/R/globals.R
@@ -40,7 +40,11 @@ utils::globalVariables(c(
   'status', 'stool.1.condition', 'stool.2.condition', 'stool.col.int', 'stool.date.sent.to.lab', 'stool1missing', 'stool1tostool2',
   'stool2missing', 'stoolmissing', 't.daysstooltolab', 't.investtostool1', 't.nottoinvest', 't.ontonot', 't.stool1tostool2', 'timely',
   'timely > 3', 'timelystool', 'today_date', 'tot.dist.adeq', 'tot.freq.x', 'tot.freq.y', 'type', 'u15pop.prov', 'vdpv.1', 'vdpv.2',
-  'vdpv.3', 'wild.1', 'wild.3', 'yr.sia'
+  'vdpv.3', 'wild.1', 'wild.3', 'yr.sia',
+
+  #new additions to v1.2
+  'days.coll.sent.field', 'days.rec.lab.culture', 'days.rec.nat.sent.lab',
+  'days.sent.field.rec.nat', 'days.sent.lab.rec.lab'
 
 
 ))


### PR DESCRIPTION
This pull request enhances the functions `generate_ctry_timeliness_graph()` and `generate_prov_timeliness_graph()` to show additional subinterval data. Changes were made to the lab cleaning script for both WHO and regional lab data so it can handle the recent changes in the code.

Additionally, this pull request has a critical update on local lab data loading. The change fixes a bug where lab data is not loaded when a local lab path is designated during `init_dr`, if lab data already exists in the `data` folder within the desk review folder of a country.