### PR TITLE
127 add ability to write png files to edav io

### DIFF
--- a/R/dal.R
+++ b/R/dal.R
@@ -173,13 +173,18 @@ edav_io <- function(
       AzureStor::storage_write_csv(object = obj, container = azcontainer, file = file_loc)
     }
 
-    if (!grepl(".cvs|.rds", file_loc)){
+    if ("gg" %in% class(obj)){
       temp <- tempfile()
       ggplot2::ggsave(filename = paste0(temp, "/", sub(".*\\/", "", file_loc)), plot = obj)
       AzureStor::storage_upload(container = azcontainer, dest = file_loc,
                                 src = paste0(temp, "/", sub(".*\\/", "", file_loc)))
       unlink(temp)
     }
+
+    if ("flextable" %in% class(obj)){
+
+    }
+
   }
 
   if (io == "delete") {

--- a/R/dal.R
+++ b/R/dal.R
@@ -95,6 +95,10 @@ edav_io <- function(
     stop("Need to supply an object to be written")
   }
 
+  if (io == "write" & grepl(".png", file_loc) & is.na(plot_name)){
+    stop(".png files need a plot_name to be written")
+  }
+
   if (io == "list") {
     if (!AzureStor::storage_dir_exists(azcontainer, file_loc)) {
       stop("Directory does not exist")
@@ -181,8 +185,8 @@ edav_io <- function(
     if (grepl(".png", file_loc)){
       temp <- tempfile()
       ggplot2::ggsave(filename = paste0(temp, "/", plot_name, ".png"), plot = obj)
-      AzureStor::storage_upload(container = azcontainer,
-                                dest = file_loc, src = paste0(temp, "/", plot_name, ".png"))
+      AzureStor::storage_upload(container = azcontainer, dest = file_loc,
+                                src = paste0(temp, "/", plot_name, ".png"))
       unlink(temp)
     }
   }

--- a/R/dal.R
+++ b/R/dal.R
@@ -185,6 +185,7 @@ edav_io <- function(
       temp <- tempfile()
       flextable::save_as_image(obj, path = paste0(temp, "/", sub(".*\\/", "", file_loc)))
       AzureStor::storage_upload(container = azcontainer, dest = file_loc,
+                                src = paste0(temp, "/", sub(".*\\/", "", file_loc)))
       unlink(temp)
     }
 

--- a/R/dal.R
+++ b/R/dal.R
@@ -179,7 +179,7 @@ edav_io <- function(
       AzureStor::storage_write_csv(object = obj, container = azcontainer, file = file_loc)
     }
 
-    if ("gg" %in% class(obj)){
+    if ("gg" %in% class(obj)) {
       temp <- tempfile()
       ggplot2::ggsave(filename = paste0(temp, "/", sub(".*\\/", "", file_loc)), plot = obj)
       AzureStor::storage_upload(container = azcontainer, dest = file_loc,
@@ -187,7 +187,7 @@ edav_io <- function(
       unlink(temp)
     }
 
-    if ("flextable" %in% class(obj)){
+    if ("flextable" %in% class(obj)) {
       temp <- tempfile()
       flextable::save_as_image(obj, path = paste0(temp, "/", sub(".*\\/", "", file_loc)))
       AzureStor::storage_upload(container = azcontainer, dest = file_loc,

--- a/R/dal.R
+++ b/R/dal.R
@@ -164,8 +164,8 @@ edav_io <- function(
   }
 
   if (io == "write") {
-    if (!grepl(".rds|.csv", file_loc)) {
-      stop("At the moment only 'rds' 'rda' and 'csv' are supported for reading.")
+    if (!grepl(".rds|.csv|.png", file_loc)) {
+      stop("At the moment only 'rds' 'rda' 'csv' and 'png' are supported for reading.")
     }
 
     if (grepl(".rds", file_loc)) {
@@ -174,6 +174,10 @@ edav_io <- function(
 
     if (grepl(".csv", file_loc)) {
       AzureStor::storage_write_csv(object = obj, container = azcontainer, file = file_loc)
+    }
+
+    if (grepl(".csv", file_loc)){
+
     }
   }
 

--- a/R/dal.R
+++ b/R/dal.R
@@ -62,6 +62,7 @@ get_azure_storage_connection <- function(
 #' @param file_loc str: location to "read", "write", "exists.dir", "exists.file", "create" or "list", can include
 #' the information in `default_dir` if you set that parameter to NULL.
 #' @param obj default NULL object to be saved, needed for "write"
+#' @param plot_name str: default NULL, name of plot to save, needed for "write" if saving non-rds/csv
 #' @param azcontainer azure container object returned from `get_azure_storage_connection()`
 #' @param force_delete boolean: use delete io without verification in the command line
 #' @returns output dependent on "io"
@@ -71,6 +72,7 @@ edav_io <- function(
     default_dir = "GID/PEB/SIR",
     file_loc = NULL,
     obj = NULL,
+    plot_name = NULL,
     azcontainer = suppressMessages(get_azure_storage_connection()),
     force_delete = F) {
   if (!is.null(file_loc)) {
@@ -165,7 +167,7 @@ edav_io <- function(
 
   if (io == "write") {
     if (!grepl(".rds|.csv|.png", file_loc)) {
-      stop("At the moment only 'rds' 'rda' 'csv' and 'png' are supported for reading.")
+      stop("At the moment only 'rds' 'rda' 'csv' and 'png' are supported for writing.")
     }
 
     if (grepl(".rds", file_loc)) {
@@ -176,8 +178,12 @@ edav_io <- function(
       AzureStor::storage_write_csv(object = obj, container = azcontainer, file = file_loc)
     }
 
-    if (grepl(".csv", file_loc)){
-
+    if (grepl(".png", file_loc)){
+      temp <- tempfile()
+      ggplot2::ggsave(filename = paste0(temp, "/", plot_name, ".png"), plot = obj)
+      AzureStor::storage_upload(container = suppressMessages(get_azure_storage_connection()),
+                                dest = file_loc, src = paste0(temp, "/", plot_name, ".png"))
+      unlink(temp)
     }
   }
 

--- a/R/dal.R
+++ b/R/dal.R
@@ -83,10 +83,10 @@ edav_io <- function(
     file_loc <- default_dir
   }
 
-  opts <- c("read", "write", "delete", "list", "exists.dir", "exists.file", "create")
+  opts <- c("read", "write", "delete", "list", "exists.dir", "exists.file", "create", "upload")
 
   if (!io %in% opts) {
-    stop("io: must be 'read', 'write', 'exists.dir', 'exists.file','create', 'delete' or 'list'")
+    stop("io: must be 'read', 'write', 'exists.dir', 'exists.file','create', 'delete' 'list' or 'upload'")
   }
 
   if (io == "write" & is.null(obj)) {
@@ -188,6 +188,9 @@ edav_io <- function(
                                 src = paste0(temp, "/", sub(".*\\/", "", file_loc)))
       unlink(temp)
     }
+  }
+
+  if (io == "upload") {
 
   }
 

--- a/R/dal.R
+++ b/R/dal.R
@@ -197,7 +197,7 @@ edav_io <- function(
   }
 
   if (io == "upload") {
-
+    AzureStor::storage_upload(container = azcontainer, dest = file_loc, src = local_path)
   }
 
   if (io == "delete") {

--- a/R/dal.R
+++ b/R/dal.R
@@ -95,6 +95,10 @@ edav_io <- function(
     stop("Need to supply an object to be written")
   }
 
+  if (io == "upload" & is.null(local_path)) {
+    stop("Need to supply file pathway of file to be uploaded")
+  }
+
   if (io == "list") {
     if (!AzureStor::storage_dir_exists(azcontainer, file_loc)) {
       stop("Directory does not exist")

--- a/R/dal.R
+++ b/R/dal.R
@@ -181,7 +181,7 @@ edav_io <- function(
     if (grepl(".png", file_loc)){
       temp <- tempfile()
       ggplot2::ggsave(filename = paste0(temp, "/", plot_name, ".png"), plot = obj)
-      AzureStor::storage_upload(container = suppressMessages(get_azure_storage_connection()),
+      AzureStor::storage_upload(container = azcontainer,
                                 dest = file_loc, src = paste0(temp, "/", plot_name, ".png"))
       unlink(temp)
     }

--- a/R/dal.R
+++ b/R/dal.R
@@ -64,6 +64,7 @@ get_azure_storage_connection <- function(
 #' @param obj default NULL object to be saved, needed for "write"
 #' @param azcontainer azure container object returned from `get_azure_storage_connection()`
 #' @param force_delete boolean: use delete io without verification in the command line
+#' @param local_path str: local file pathway to upload a file to edav, default is NULL, only required when using 'upload' option
 #' @returns output dependent on "io"
 #' @export
 edav_io <- function(
@@ -72,7 +73,8 @@ edav_io <- function(
     file_loc = NULL,
     obj = NULL,
     azcontainer = suppressMessages(get_azure_storage_connection()),
-    force_delete = F) {
+    force_delete = F,
+    local_path = NULL) {
   if (!is.null(file_loc)) {
     if (is.null(default_dir)) {
       file_loc <- file_loc

--- a/R/dal.R
+++ b/R/dal.R
@@ -49,7 +49,7 @@ get_azure_storage_connection <- function(
 #' Helper function to read and write key data to the EDAV environment
 #'
 #' @description Helper function read and write key data to EDAV
-#' @import cli AzureStor
+#' @import cli AzureStor ggplot2 flextable
 #' @param io str: "read", "write", "delete", "exists.dir", "exists.file", "create" or "list".
 #' "read" - read a file from EDAV, must be an rds, csv, or rda;
 #' "write" - write a file from EDAV, must be an rds, csv or rda;
@@ -182,7 +182,10 @@ edav_io <- function(
     }
 
     if ("flextable" %in% class(obj)){
-
+      temp <- tempfile()
+      flextable::save_as_image(obj, path = paste0(temp, "/", sub(".*\\/", "", file_loc)))
+      AzureStor::storage_upload(container = azcontainer, dest = file_loc,
+      unlink(temp)
     }
 
   }

--- a/R/dal.R
+++ b/R/dal.R
@@ -50,13 +50,14 @@ get_azure_storage_connection <- function(
 #'
 #' @description Helper function read and write key data to EDAV
 #' @import cli AzureStor ggplot2 flextable
-#' @param io str: "read", "write", "delete", "exists.dir", "exists.file", "create" or "list".
+#' @param io str: "read", "write", "delete", "exists.dir", "exists.file", "create", "list", or "upload".
 #' "read" - read a file from EDAV, must be an rds, csv, or rda;
 #' "write" - write a file from EDAV, must be an rds, csv or rda;
 #' "exists.dir" - returns a boolean after checking to see if a folder exists;
 #' "exists.file" - returns a boolean after checking to see if a file exists;
 #' "create" - creates a folder and all preceding folders
 #' "list" - returns a tibble with all objects in a folder
+#' "upload" - moves a file of any type to EDAV
 #' @param default_dir str: "GID/PEB/SIR" - the default directory for all SIR data in EDAV, can be set to NULL
 #' if you provide the full directory path in `file_loc`
 #' @param file_loc str: location to "read", "write", "exists.dir", "exists.file", "create" or "list", can include


### PR DESCRIPTION
to test create a plot and a flextable and write it to edav from R. for non gg or flextable objects specify a non-rds or csv file from your local and upload

ex.
edav_io(io = "write", obj = plot, file_loc = "sia_impact_test/plot.png")
edav_io(io = "write", obj = flex, file_loc = "sia_impact_test/flex.png")

edav_io(io = "upload", file_loc = "sia_impact_test/report.html", 
        local_path = "C:/Users/uic3/Desktop/gitrepos/core-2.0/sia_impact_pipeline/reports/SIA Impact Report_FULL_2024-10-02.html")
 