### PR TITLE
137 add spatial dev option to load clean spatials

### DIFF
--- a/R/dal.R
+++ b/R/dal.R
@@ -1381,6 +1381,7 @@ load_clean_dist_sp <- function(azcontainer = suppressMessages(get_azure_storage_
 #' @param st.year int: earlier year of spatial data you want to pull - default is 2000
 #' @param data.only boolean: default F, if true, returns a rectangular tibble instead of a shape file
 #' @param type str: "long" or NULL, default NULL, if "long" returns a spatial object for every year group
+#' @param version str: "regular" or "dev", default is "regular, specifies whether to return standard shapefiles or new shapefiles still under evaluation/development
 #' @returns tibble or sf dataframe
 #' @export
 load_clean_prov_sp <- function(azcontainer = suppressMessages(get_azure_storage_connection()),
@@ -1393,7 +1394,14 @@ load_clean_prov_sp <- function(azcontainer = suppressMessages(get_azure_storage_
                                data.only = F,
                                type = NULL,
                                version = "regular") {
-  cli::cli_alert_info("Loading province spatial files")
+
+  if(version == "dev"){
+    fp <- "GID/PEB/SIR/Data/spatial_dev/global.prov.rds"
+    cli::cli_alert_info("Loading under development province spatial files")
+  }else{
+    cli::cli_alert_info("Loading province spatial files")
+  }
+
   out <- suppressWarnings(AzureStor::storage_load_rds(azcontainer, fp)) |>
     dplyr::mutate(
       yr.st = lubridate::year(STARTDATE),

--- a/R/dal.R
+++ b/R/dal.R
@@ -1469,7 +1469,14 @@ load_clean_ctry_sp <- function(azcontainer = suppressMessages(get_azure_storage_
                                data.only = F,
                                type = NULL,
                                version = "standard") {
-  cli::cli_alert_info("Loading country spatial files")
+
+  if(version == "dev"){
+    fp <- "GID/PEB/SIR/Data/spatial_dev/global.ctry.rds"
+    cli::cli_alert_info("Loading under development country spatial files")
+  }else{
+    cli::cli_alert_info("Loading country spatial files")
+  }
+
   out <- suppressWarnings(AzureStor::storage_load_rds(azcontainer, fp)) |>
     dplyr::mutate(
       yr.st = lubridate::year(STARTDATE),

--- a/R/dal.R
+++ b/R/dal.R
@@ -1311,9 +1311,11 @@ load_clean_dist_sp <- function(azcontainer = suppressMessages(get_azure_storage_
 
   if(version == "dev"){
     fp <- "GID/PEB/SIR/Data/spatial_dev/global.dist.rds"
+    cli::cli_alert_info("Loading under development district spatial files")
+  }else{
+    cli::cli_alert_info("Loading district spatial files")
   }
 
-  cli::cli_alert_info("Loading district spatial files")
   out <- suppressWarnings(AzureStor::storage_load_rds(azcontainer, fp)) |>
     dplyr::mutate(
       STARTDATE = lubridate::as_date(STARTDATE),
@@ -1389,7 +1391,8 @@ load_clean_prov_sp <- function(azcontainer = suppressMessages(get_azure_storage_
                                end.year = lubridate::year(Sys.Date()),
                                st.year = 2000,
                                data.only = F,
-                               type = NULL) {
+                               type = NULL,
+                               version = "regular") {
   cli::cli_alert_info("Loading province spatial files")
   out <- suppressWarnings(AzureStor::storage_load_rds(azcontainer, fp)) |>
     dplyr::mutate(

--- a/R/dal.R
+++ b/R/dal.R
@@ -1296,7 +1296,7 @@ duplicate_check <- function(.raw.data = raw.data) {
 #' @param st.year int: earlier year of spatial data you want to pull - default is 2000
 #' @param data.only boolean: default F, if true, returns a rectangular tibble instead of a shape file
 #' @param type str: "long" or NULL, default NULL, if "long" returns a spatial object for every year group
-#' @param version str: "regular" or "dev", default is "regular, specifies whether to return standard shapefiles or new shapefiles still under evaluation/development
+#' @param version str: "standard" or "dev", default is "standard", specifies whether to return standard shapefiles or new shapefiles still under evaluation/development
 #' @returns tibble or sf dataframe
 #' @export
 load_clean_dist_sp <- function(azcontainer = suppressMessages(get_azure_storage_connection()),
@@ -1381,7 +1381,7 @@ load_clean_dist_sp <- function(azcontainer = suppressMessages(get_azure_storage_
 #' @param st.year int: earlier year of spatial data you want to pull - default is 2000
 #' @param data.only boolean: default F, if true, returns a rectangular tibble instead of a shape file
 #' @param type str: "long" or NULL, default NULL, if "long" returns a spatial object for every year group
-#' @param version str: "regular" or "dev", default is "regular, specifies whether to return standard shapefiles or new shapefiles still under evaluation/development
+#' @param version str: "standard" or "dev", default is "standard", specifies whether to return standard shapefiles or new shapefiles still under evaluation/development
 #' @returns tibble or sf dataframe
 #' @export
 load_clean_prov_sp <- function(azcontainer = suppressMessages(get_azure_storage_connection()),
@@ -1393,7 +1393,7 @@ load_clean_prov_sp <- function(azcontainer = suppressMessages(get_azure_storage_
                                st.year = 2000,
                                data.only = F,
                                type = NULL,
-                               version = "regular") {
+                               version = "standard") {
 
   if(version == "dev"){
     fp <- "GID/PEB/SIR/Data/spatial_dev/global.prov.rds"
@@ -1457,6 +1457,7 @@ load_clean_prov_sp <- function(azcontainer = suppressMessages(get_azure_storage_
 #' @param st.year int: earlier year of spatial data you want to pull - default is 2000
 #' @param data.only boolean: default F, if true, returns a rectangular tibble instead of a shape file
 #' @param type str: "long" or NULL, default NULL, if "long" returns a spatial object for every year group
+#' @param version str: "standard" or "dev", default is "standard", specifies whether to return standard shapefiles or new shapefiles still under evaluation/development
 #' @returns tibble or sf dataframe
 #' @export
 load_clean_ctry_sp <- function(azcontainer = suppressMessages(get_azure_storage_connection()),
@@ -1466,7 +1467,8 @@ load_clean_ctry_sp <- function(azcontainer = suppressMessages(get_azure_storage_
                                end.year = lubridate::year(Sys.Date()),
                                st.year = 2000,
                                data.only = F,
-                               type = NULL) {
+                               type = NULL,
+                               version = "standard") {
   cli::cli_alert_info("Loading country spatial files")
   out <- suppressWarnings(AzureStor::storage_load_rds(azcontainer, fp)) |>
     dplyr::mutate(

--- a/R/dal.R
+++ b/R/dal.R
@@ -1296,6 +1296,7 @@ duplicate_check <- function(.raw.data = raw.data) {
 #' @param st.year int: earlier year of spatial data you want to pull - default is 2000
 #' @param data.only boolean: default F, if true, returns a rectangular tibble instead of a shape file
 #' @param type str: "long" or NULL, default NULL, if "long" returns a spatial object for every year group
+#' @param version str: "regular" or "dev", default is "regular, specifies whether to return standard shapefiles or new shapefiles still under evaluation/development
 #' @returns tibble or sf dataframe
 #' @export
 load_clean_dist_sp <- function(azcontainer = suppressMessages(get_azure_storage_connection()),
@@ -1305,7 +1306,13 @@ load_clean_dist_sp <- function(azcontainer = suppressMessages(get_azure_storage_
                                end.year = lubridate::year(Sys.Date()),
                                st.year = 2000,
                                data.only = F,
-                               type = NULL) {
+                               type = NULL,
+                               version = "standard") {
+
+  if(version == "dev"){
+    fp <- "GID/PEB/SIR/Data/spatial_dev/global.dist.rds"
+  }
+
   cli::cli_alert_info("Loading district spatial files")
   out <- suppressWarnings(AzureStor::storage_load_rds(azcontainer, fp)) |>
     dplyr::mutate(


### PR DESCRIPTION
load_clean spatial functions now contain an additional parameter, version. options are "standard" or "dev", standard is default. 

to test please use the functions to pull the standard and dev shape files and compare, there are more provinces/districts in the dev shapefiles and the dev shapefiles contain 2 extra variables, "AREA_SQM" and "LENGTH_M" 

you can check this adm2guid {BDB536A7-CA9D-439F-9CF7-F7EFF5D8A23E} in the district files, it should be in the dev shapes but not the standard shapes 