### PR TITLE
🐛 Update geomatching algorithm when cleaning regional lab data 

### DIFF
--- a/R/dr.lab.functions.R
+++ b/R/dr.lab.functions.R
@@ -397,7 +397,7 @@ clean_lab_data_who <- function(ctry.data, start.date, end.date, delim = "-") {
   lab.data2 <- lab.data2 |>
     dplyr::mutate(dplyr::across(
       dplyr::starts_with("Date"),
-      \(x) lubridate::as_date(x)
+      \(x) as.Date.character(x, tryFormats = c("%Y-%m-%d", "%Y/%m%/%d", "%m/%d/%Y"))
     ))
   cli::cli_process_done()
 
@@ -539,23 +539,19 @@ clean_lab_data_who <- function(ctry.data, start.date, end.date, delim = "-") {
     dplyr::left_join(prov_lookup_table) |>
     dplyr::left_join(prov_lookup_table, by = dplyr::join_by(epid_prov, year)) |>
     dplyr::mutate(
-      prov.x = dplyr::if_else(is.na(.data$prov.x) & !is.na(.data$prov.y), .data$prov.y, .data$prov.x),
-      adm1guid.x = dplyr::if_else(is.na(.data$adm1guid.x) & !is.na(.data$adm1guid.y), .data$adm1guid.y, .data$adm1guid.y)
+      prov = dplyr::coalesce(.data$prov.x, .data$prov.y),
+      adm1guid = dplyr::coalesce(.data$adm1guid.x, .data$adm1guid.y)
     ) |>
     dplyr::left_join(dist_lookup_table) |>
     dplyr::left_join(dist_lookup_table, by = dplyr::join_by(epid_dist, year)) |>
     dplyr::mutate(
-      dist.x = dplyr::if_else(is.na(.data$dist.x) & !is.na(.data$dist.y), .data$dist.y, .data$dist.x),
-      adm2guid.x = dplyr::if_else(is.na(.data$adm2guid.x) & !is.na(.data$adm2guid.y), .data$adm2guid.y, .data$adm2guid.y)
+      dist = dplyr::coalesce(.data$dist.x, .data$dist.y),
+      adm2guid = dplyr::coalesce(.data$adm2guid.x, .data$adm2guid.y)
     ) |>
     dplyr::rename(
-      adm0guid = "adm0guid.x",
-      adm1guid = "adm1guid.x",
-      adm2guid = "adm2guid.x",
-      prov = "prov.x",
-      dist = "dist.x"
+      adm0guid = "adm0guid.x"
     ) |>
-    dplyr::select(-dplyr::ends_with(".y"))
+    dplyr::select(-dplyr::ends_with(".y"), -dplyr::ends_with(".x"))
 
   # check for correctness
   check <- test |>

--- a/R/dr.lab.functions.R
+++ b/R/dr.lab.functions.R
@@ -394,12 +394,12 @@ clean_lab_data_who <- function(ctry.data, start.date, end.date, delim = "-") {
   cli::cli_process_start("Filtering for cases with valid dates")
   lab.data2 <- lab.data %>%
     dplyr::filter((days.collect.lab >= 0 | is.na(days.collect.lab)) &
-                    (days.lab.culture >= 0 | is.na(days.lab.culture)) &
-                    (days.seq.ship >= 0 | is.na(days.seq.ship)) &
-                    (days.lab.seq >= 0 | is.na(days.lab.seq)) &
-                    (days.itd.seqres >= 0 | is.na(days.itd.seqres)) &
-                    (days.itd.arriveseq >= 0 | is.na(days.itd.arriveseq)) &
-                    (days.seq.rec.res >= 0 | is.na(days.seq.rec.res))) |>
+      (days.lab.culture >= 0 | is.na(days.lab.culture)) &
+      (days.seq.ship >= 0 | is.na(days.seq.ship)) &
+      (days.lab.seq >= 0 | is.na(days.lab.seq)) &
+      (days.itd.seqres >= 0 | is.na(days.itd.seqres)) &
+      (days.itd.arriveseq >= 0 | is.na(days.itd.arriveseq)) &
+      (days.seq.rec.res >= 0 | is.na(days.seq.rec.res))) |>
     dplyr::filter(
       year >= lubridate::year(start.date) & year <= lubridate::year(end.date),
       CaseOrContact == "1-Case"
@@ -409,8 +409,10 @@ clean_lab_data_who <- function(ctry.data, start.date, end.date, delim = "-") {
   # remove time portion of any date time columns
   cli::cli_process_start("Converting date/date-time character columns to date columns")
   lab.data2 <- lab.data2 |>
-    dplyr::mutate(dplyr::across(dplyr::starts_with("Date"),
-                                \(x) lubridate::as_date(x)))
+    dplyr::mutate(dplyr::across(
+      dplyr::starts_with("Date"),
+      \(x) lubridate::as_date(x)
+    ))
   cli::cli_process_done()
 
   # Don't run additional cleaning steps if no data is present
@@ -559,7 +561,7 @@ clean_lab_data_who <- function(ctry.data, start.date, end.date, delim = "-") {
       days.sent.field.rec.nat = as.numeric(.data$DateStoolReceivedNatLevel - .data$DateStoolSentfromField),
       days.rec.nat.sent.lab = as.numeric(.data$DateStoolSentToLab - .data$DateStoolReceivedNatLevel),
       days.sent.lab.rec.lab = as.numeric(.data$DateStoolReceivedinLab - .data$DateStoolSentToLab),
-      days.rec.lab.culture =  as.numeric(.data$DateFinalCellCultureResults - .data$DateStoolReceivedinLab),
+      days.rec.lab.culture = as.numeric(.data$DateFinalCellCultureResults - .data$DateStoolReceivedinLab),
     )
 
   return(lab.data2)
@@ -598,7 +600,7 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
   ) {
     lab.data <- lab.data |>
       dplyr::mutate(Name = dplyr::if_else(stringr::str_detect(.data$Name, "(?i)IVOIRE"),
-                                          "COTE D'IVOIRE", .data$Name
+        "COTE D'IVOIRE", .data$Name
       ))
   }
 
@@ -661,8 +663,8 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
           "DateRArmIsolate",
           "DateofSequencing",
           "DateNotificationtoHQ"
-        )), \(x) as.Date.character(x, tryFormats = c("%Y-%m-%d", "%Y/%m%/%d", "%m/%d/%Y"))
-        ))
+        )), \(x) as.Date.character(x, tryFormats = c("%Y-%m-%d", "%Y/%m%/%d", "%m/%d/%Y")))
+      )
     cli::cli_process_done()
 
 
@@ -745,12 +747,12 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
     emro.lab.05 <- emro.lab.05 |>
       # filtering out negative time intervals
       dplyr::filter((days.collect.lab >= 0 | is.na(days.collect.lab)) &
-                      (days.lab.culture >= 0 | is.na(days.lab.culture)) &
-                      (days.seq.ship >= 0 | is.na(days.seq.ship)) &
-                      (days.lab.seq >= 0 | is.na(days.lab.seq)) &
-                      (days.itd.seqres >= 0 | is.na(days.itd.seqres)) &
-                      (days.itd.arriveseq >= 0 | is.na(days.itd.arriveseq)) &
-                      (days.seq.rec.res >= 0 | is.na(days.seq.rec.res)))
+        (days.lab.culture >= 0 | is.na(days.lab.culture)) &
+        (days.seq.ship >= 0 | is.na(days.seq.ship)) &
+        (days.lab.seq >= 0 | is.na(days.lab.seq)) &
+        (days.itd.seqres >= 0 | is.na(days.itd.seqres)) &
+        (days.itd.arriveseq >= 0 | is.na(days.itd.arriveseq)) &
+        (days.seq.rec.res >= 0 | is.na(days.seq.rec.res)))
     cli::cli_process_done()
 
     cli::cli_process_start("Filtering nonsensical dates")
@@ -803,8 +805,8 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
           "DateRArmIsolate",
           "DateofSequencing",
           "DateNotificationtoHQ"
-        )), \(x) as.Date.character(x, "%m/%d/%Y")
-        ))
+        )), \(x) as.Date.character(x, "%m/%d/%Y"))
+      )
     cli::cli_process_done()
     # This is a very quick clean and can be improved upon with futher steps such as:
     #  - eliminating nonsensical dates
@@ -876,12 +878,12 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
     afro.lab.05 <- afro.lab.05 |>
       # filtering out negative time intervals
       dplyr::filter((days.collect.lab >= 0 | is.na(days.collect.lab)) &
-                      (days.lab.culture >= 0 | is.na(days.lab.culture)) &
-                      (days.seq.ship >= 0 | is.na(days.seq.ship)) &
-                      (days.lab.seq >= 0 | is.na(days.lab.seq)) &
-                      (days.itd.seqres >= 0 | is.na(days.itd.seqres)) &
-                      (days.itd.arriveseq >= 0 | is.na(days.itd.arriveseq)) &
-                      (days.seq.rec.res >= 0 | is.na(days.seq.rec.res)))
+        (days.lab.culture >= 0 | is.na(days.lab.culture)) &
+        (days.seq.ship >= 0 | is.na(days.seq.ship)) &
+        (days.lab.seq >= 0 | is.na(days.lab.seq)) &
+        (days.itd.seqres >= 0 | is.na(days.itd.seqres)) &
+        (days.itd.arriveseq >= 0 | is.na(days.itd.arriveseq)) &
+        (days.seq.rec.res >= 0 | is.na(days.seq.rec.res)))
     cli::cli_process_done()
     cli::cli_process_start("Filtering nonsensical dates")
     afro.lab.05 <- afro.lab.05 |>
@@ -946,8 +948,9 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
 
   lab.data <- lab.data |>
     dplyr::left_join(geo_lookup_table,
-                     multiple = "any",
-                     by = dplyr::join_by(epid_ctry, epid_prov, epid_dist, year))
+      multiple = "any",
+      by = dplyr::join_by(epid_ctry, epid_prov, epid_dist, year)
+    )
   lab.data <- lab.data |>
     dplyr::rename(ctry.code2 = "epid_ctry")
   lab.data <- lab.data |>
@@ -967,7 +970,7 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
       days.sent.field.rec.nat = NA,
       days.rec.nat.sent.lab = NA,
       days.sent.lab.rec.lab = NA,
-      days.rec.lab.culture =  NA,
+      days.rec.lab.culture = NA,
     )
 
   return(lab.data)

--- a/R/dr.lab.functions.R
+++ b/R/dr.lab.functions.R
@@ -394,12 +394,12 @@ clean_lab_data_who <- function(ctry.data, start.date, end.date, delim = "-") {
   cli::cli_process_start("Filtering for cases with valid dates")
   lab.data2 <- lab.data %>%
     dplyr::filter((days.collect.lab >= 0 | is.na(days.collect.lab)) &
-      (days.lab.culture >= 0 | is.na(days.lab.culture)) &
-      (days.seq.ship >= 0 | is.na(days.seq.ship)) &
-      (days.lab.seq >= 0 | is.na(days.lab.seq)) &
-      (days.itd.seqres >= 0 | is.na(days.itd.seqres)) &
-      (days.itd.arriveseq >= 0 | is.na(days.itd.arriveseq)) &
-      (days.seq.rec.res >= 0 | is.na(days.seq.rec.res))) |>
+                    (days.lab.culture >= 0 | is.na(days.lab.culture)) &
+                    (days.seq.ship >= 0 | is.na(days.seq.ship)) &
+                    (days.lab.seq >= 0 | is.na(days.lab.seq)) &
+                    (days.itd.seqres >= 0 | is.na(days.itd.seqres)) &
+                    (days.itd.arriveseq >= 0 | is.na(days.itd.arriveseq)) &
+                    (days.seq.rec.res >= 0 | is.na(days.seq.rec.res))) |>
     dplyr::filter(
       year >= lubridate::year(start.date) & year <= lubridate::year(end.date),
       CaseOrContact == "1-Case"
@@ -598,7 +598,7 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
   ) {
     lab.data <- lab.data |>
       dplyr::mutate(Name = dplyr::if_else(stringr::str_detect(.data$Name, "(?i)IVOIRE"),
-        "COTE D'IVOIRE", .data$Name
+                                          "COTE D'IVOIRE", .data$Name
       ))
   }
 
@@ -661,8 +661,8 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
           "DateRArmIsolate",
           "DateofSequencing",
           "DateNotificationtoHQ"
-        )), \(x) as.Date.character(x, "%m/%d/%Y")
-      ))
+        )), \(x) as.Date.character(x, tryFormats = c("%Y-%m-%d", "%Y/%m%/%d", "%m/%d/%Y"))
+        ))
     cli::cli_process_done()
 
 
@@ -745,12 +745,12 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
     emro.lab.05 <- emro.lab.05 |>
       # filtering out negative time intervals
       dplyr::filter((days.collect.lab >= 0 | is.na(days.collect.lab)) &
-        (days.lab.culture >= 0 | is.na(days.lab.culture)) &
-        (days.seq.ship >= 0 | is.na(days.seq.ship)) &
-        (days.lab.seq >= 0 | is.na(days.lab.seq)) &
-        (days.itd.seqres >= 0 | is.na(days.itd.seqres)) &
-        (days.itd.arriveseq >= 0 | is.na(days.itd.arriveseq)) &
-        (days.seq.rec.res >= 0 | is.na(days.seq.rec.res)))
+                      (days.lab.culture >= 0 | is.na(days.lab.culture)) &
+                      (days.seq.ship >= 0 | is.na(days.seq.ship)) &
+                      (days.lab.seq >= 0 | is.na(days.lab.seq)) &
+                      (days.itd.seqres >= 0 | is.na(days.itd.seqres)) &
+                      (days.itd.arriveseq >= 0 | is.na(days.itd.arriveseq)) &
+                      (days.seq.rec.res >= 0 | is.na(days.seq.rec.res)))
     cli::cli_process_done()
 
     cli::cli_process_start("Filtering nonsensical dates")
@@ -804,7 +804,7 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
           "DateofSequencing",
           "DateNotificationtoHQ"
         )), \(x) as.Date.character(x, "%m/%d/%Y")
-      ))
+        ))
     cli::cli_process_done()
     # This is a very quick clean and can be improved upon with futher steps such as:
     #  - eliminating nonsensical dates
@@ -876,12 +876,12 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
     afro.lab.05 <- afro.lab.05 |>
       # filtering out negative time intervals
       dplyr::filter((days.collect.lab >= 0 | is.na(days.collect.lab)) &
-        (days.lab.culture >= 0 | is.na(days.lab.culture)) &
-        (days.seq.ship >= 0 | is.na(days.seq.ship)) &
-        (days.lab.seq >= 0 | is.na(days.lab.seq)) &
-        (days.itd.seqres >= 0 | is.na(days.itd.seqres)) &
-        (days.itd.arriveseq >= 0 | is.na(days.itd.arriveseq)) &
-        (days.seq.rec.res >= 0 | is.na(days.seq.rec.res)))
+                      (days.lab.culture >= 0 | is.na(days.lab.culture)) &
+                      (days.seq.ship >= 0 | is.na(days.seq.ship)) &
+                      (days.lab.seq >= 0 | is.na(days.lab.seq)) &
+                      (days.itd.seqres >= 0 | is.na(days.itd.seqres)) &
+                      (days.itd.arriveseq >= 0 | is.na(days.itd.arriveseq)) &
+                      (days.seq.rec.res >= 0 | is.na(days.seq.rec.res)))
     cli::cli_process_done()
     cli::cli_process_start("Filtering nonsensical dates")
     afro.lab.05 <- afro.lab.05 |>
@@ -932,17 +932,22 @@ clean_lab_data_regional <- function(ctry.data, start.date, end.date, delim = "-"
       too_few = "align_start"
     ) |>
     dplyr::select(
-      dplyr::contains("epid"),
+      "epid_ctry",
+      "epid_prov",
+      "epid_dist",
       "ctry",
       "prov",
       "dist",
       dplyr::matches("adm[0-3]guid"),
       "year"
     ) |>
+    dplyr::arrange(year) |>
     dplyr::distinct()
 
   lab.data <- lab.data |>
-    dplyr::left_join(geo_lookup_table, by = dplyr::join_by(epid_ctry, epid_prov, epid_dist, year))
+    dplyr::left_join(geo_lookup_table,
+                     multiple = "any",
+                     by = dplyr::join_by(epid_ctry, epid_prov, epid_dist, year))
   lab.data <- lab.data |>
     dplyr::rename(ctry.code2 = "epid_ctry")
   lab.data <- lab.data |>


### PR DESCRIPTION
Relates to #140 

In some instances, the geomatching algorithm will explode the regional lab dataset, taking a dataset that may have 5000 rows to 10000+ rows. This fix ensures this doesn't happen. To test, run a desk review using regional lab data. Check the number of lab data before cleaning and after cleaning