### PR TITLE
❇️ Desk review mapping functions now use long spatial data

### DIFF
--- a/R/dr.figure.functions.R
+++ b/R/dr.figure.functions.R
@@ -759,10 +759,10 @@ generate_pop_map <- function(ctry.data,
 
   # Only the most recent shape file
   ctry.shape <- ctry.shape |>
-    dplyr::filter(active.year.01 == lubridate::year(end_date)) |>
+    dplyr::filter(.data$active.year.01 == lubridate::year(end_date)) |>
     dplyr::mutate(year = .data$active.year.01)
   prov.shape <- prov.shape |>
-    dplyr::filter(active.year.01 == lubridate::year(end_date)) |>
+    dplyr::filter(.data$active.year.01 == lubridate::year(end_date)) |>
     dplyr::mutate(year = .data$active.year.01)
 
   # Merge with province
@@ -872,13 +872,13 @@ generate_dist_pop_map <- function(ctry.data,
   }
 
   ctry.shape <- ctry.shape |>
-    dplyr::filter(active.year.01 == lubridate::year(end_date)) |>
+    dplyr::filter(.data$active.year.01 == lubridate::year(end_date)) |>
     dplyr::mutate(year = .data$active.year.01)
   prov.shape <- prov.shape |>
-    dplyr::filter(active.year.01 == lubridate::year(end_date)) |>
+    dplyr::filter(.data$active.year.01 == lubridate::year(end_date)) |>
     dplyr::mutate(year = .data$active.year.01)
   dist.shape <- dist.shape |>
-    dplyr::filter(active.year.01 == lubridate::year(end_date)) |>
+    dplyr::filter(.data$active.year.01 == lubridate::year(end_date)) |>
     dplyr::mutate(year = .data$active.year.01)
 
   shape.prov.pop <-
@@ -976,12 +976,12 @@ generate_afp_case_map <- function(afp.all,
   }
 
   ctry.shape <- ctry.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
   prov.shape <- prov.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
@@ -1086,12 +1086,12 @@ generate_npafp_maps <- function(prov.extract,
   }
 
   ctry.shape <- ctry.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
   prov.shape <- prov.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
@@ -1282,17 +1282,17 @@ generate_npafp_maps_dist <- function(dist.extract,
   }
 
   ctry.shape <- ctry.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
   prov.shape <- prov.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
   dist.shape <- dist.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
@@ -1475,12 +1475,12 @@ generate_stool_ad_maps <- function(ctry.data,
   }
 
   ctry.shape <- ctry.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
   prov.shape <- prov.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
@@ -1672,17 +1672,17 @@ generate_stool_ad_maps_dist <- function(ctry.data,
   }
 
   ctry.shape <- ctry.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
   prov.shape <- prov.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
   dist.shape <- dist.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
@@ -1881,12 +1881,12 @@ generate_timeliness_maps <- function(ctry.data,
   }
 
   ctry.shape <- ctry.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
   prov.shape <- prov.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
@@ -2340,10 +2340,10 @@ generate_es_det_map <- function(es.data,
 
   # For this map, use the most recent shapefile
   ctry.shape <- ctry.shape |>
-    dplyr::filter(active.year.01 == lubridate::year(end_date)) |>
+    dplyr::filter(.data$active.year.01 == lubridate::year(end_date)) |>
     dplyr::mutate(year = .data$active.year.01)
   prov.shape <- prov.shape |>
-    dplyr::filter(active.year.01 == lubridate::year(end_date)) |>
+    dplyr::filter(.data$active.year.01 == lubridate::year(end_date)) |>
     dplyr::mutate(year = .data$active.year.01)
 
   es.data <- es.data |>
@@ -2489,12 +2489,12 @@ generate_iss_map <- function(iss.data,
   }
 
   ctry.shape <- ctry.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)
   prov.shape <- prov.shape |>
-    dplyr::filter(dplyr::between(active.year.01,
+    dplyr::filter(dplyr::between(.data$active.year.01,
                                  lubridate::year(start_date),
                                  lubridate::year(end_date))) |>
     dplyr::mutate(year = .data$active.year.01)

--- a/man/generate_afp_case_map.Rd
+++ b/man/generate_afp_case_map.Rd
@@ -5,7 +5,7 @@
 \title{Generate a map of AFP cases}
 \usage{
 generate_afp_case_map(
-  ctry.data,
+  afp.all,
   ctry.shape,
   prov.shape,
   start_date,
@@ -14,15 +14,15 @@ generate_afp_case_map(
 )
 }
 \arguments{
-\item{ctry.data}{RDS object containing polio country data}
+\item{afp.all}{AFP linelist containing point geometry}
 
-\item{ctry.shape}{recent country shapefile}
+\item{ctry.shape}{province shapefile in long format}
 
-\item{prov.shape}{recent province shapefile}
+\item{prov.shape}{province shapefile in long format}
 
-\item{start_date}{start date of desk review}
+\item{start_date}{start date}
 
-\item{end_date}{end date of desk review}
+\item{end_date}{end date}
 
 \item{output_path}{where to save the figure}
 }

--- a/man/generate_es_det_map.Rd
+++ b/man/generate_es_det_map.Rd
@@ -19,9 +19,9 @@ generate_es_det_map(
 
 \item{es.data.long}{ES data summary and in long format}
 
-\item{ctry.shape}{recent country shapefile}
+\item{ctry.shape}{country shapefile in long format}
 
-\item{prov.shape}{recent province shapefile}
+\item{prov.shape}{province shapefile in long format}
 
 \item{es_start_date}{ES start date}
 

--- a/man/generate_iss_map.Rd
+++ b/man/generate_iss_map.Rd
@@ -6,6 +6,7 @@
 \usage{
 generate_iss_map(
   iss.data,
+  ctry.shape,
   prov.shape,
   start_date,
   end_date,
@@ -15,11 +16,13 @@ generate_iss_map(
 \arguments{
 \item{iss.data}{tibble of ISS/eSurv data}
 
-\item{prov.shape}{shapefile containing province shapes}
+\item{ctry.shape}{country shapefile in long format}
+
+\item{prov.shape}{province shapefile in long format}
 
 \item{start_date}{start date of desk review}
 
-\item{end_date}{end date of desk review}
+\item{end_date}{end date}
 
 \item{output_path}{where to save the figure}
 }

--- a/man/generate_npafp_maps.Rd
+++ b/man/generate_npafp_maps.Rd
@@ -15,15 +15,15 @@ generate_npafp_maps(
 )
 }
 \arguments{
-\item{prov.extract}{province NPAFP rate}
+\item{prov.extract}{province NPAFP rate table}
 
-\item{ctry.shape}{recent country shape}
+\item{ctry.shape}{country shape in long format}
 
-\item{prov.shape}{recent province shape}
+\item{prov.shape}{province shape in long format}
 
-\item{start_date}{start date of desk review}
+\item{start_date}{start date}
 
-\item{end_date}{end date of desk review}
+\item{end_date}{end date}
 
 \item{output_path}{where to save the figure}
 

--- a/man/generate_npafp_maps_dist.Rd
+++ b/man/generate_npafp_maps_dist.Rd
@@ -16,17 +16,17 @@ generate_npafp_maps_dist(
 )
 }
 \arguments{
-\item{dist.extract}{NPAFP rates by district}
+\item{dist.extract}{NPAFP rates by district table.}
 
-\item{ctry.shape}{recent country shapefile}
+\item{ctry.shape}{country shapefile in long format}
 
-\item{prov.shape}{recent province shapefile}
+\item{prov.shape}{province shapefile in long format}
 
-\item{dist.shape}{recent district shapefile}
+\item{dist.shape}{district shapefile in long format}
 
-\item{start_date}{start date of desk review}
+\item{start_date}{start date}
 
-\item{end_date}{end date of desk review}
+\item{end_date}{end date}
 
 \item{output_path}{where to save the figure}
 

--- a/man/generate_pop_map.Rd
+++ b/man/generate_pop_map.Rd
@@ -6,6 +6,7 @@
 \usage{
 generate_pop_map(
   ctry.data,
+  ctry.shape,
   prov.shape,
   end_date,
   output_path = Sys.getenv("DR_FIGURE_PATH"),
@@ -13,9 +14,11 @@ generate_pop_map(
 )
 }
 \arguments{
-\item{ctry.data}{RDS object}
+\item{ctry.data}{RDS object containing country polio data}
 
-\item{prov.shape}{province of most recent shape file}
+\item{ctry.shape}{country shape file in long format}
+
+\item{prov.shape}{province shape file in long format}
 
 \item{end_date}{end date of the desk review}
 

--- a/man/generate_stool_ad_maps.Rd
+++ b/man/generate_stool_ad_maps.Rd
@@ -20,9 +20,9 @@ generate_stool_ad_maps(
 
 \item{pstool}{stool adequacy at province level}
 
-\item{ctry.shape}{recent country shapefile}
+\item{ctry.shape}{country shapefile in long format}
 
-\item{prov.shape}{recent province shapefile}
+\item{prov.shape}{province shapefile in long format}
 
 \item{start_date}{start date of desk review}
 

--- a/man/generate_stool_ad_maps_dist.Rd
+++ b/man/generate_stool_ad_maps_dist.Rd
@@ -19,17 +19,17 @@ generate_stool_ad_maps_dist(
 \arguments{
 \item{ctry.data}{RDS file of polio data for a country}
 
-\item{dstool}{district stool adequacy}
+\item{dstool}{district stool adequacy table}
 
-\item{ctry.shape}{recent country shapefile}
+\item{ctry.shape}{country shapefile in long format}
 
-\item{prov.shape}{recent province shapefile}
+\item{prov.shape}{province shapefile in long format}
 
-\item{dist.shape}{recent district shapefile}
+\item{dist.shape}{district shapefile in long format}
 
-\item{start_date}{start date of desk review}
+\item{start_date}{start date}
 
-\item{end_date}{end date of desk review}
+\item{end_date}{end date}
 
 \item{output_path}{where to save the figure}
 

--- a/man/generate_timeliness_maps.Rd
+++ b/man/generate_timeliness_maps.Rd
@@ -18,13 +18,13 @@ generate_timeliness_maps(
 \arguments{
 \item{ctry.data}{RDS file containing polio data for a country}
 
-\item{ctry.shape}{recent country shapefile}
+\item{ctry.shape}{country shapefile in long format}
 
-\item{prov.shape}{recent province shapefile}
+\item{prov.shape}{province shapefile in long format}
 
-\item{start_date}{start date of desk review}
+\item{start_date}{start date}
 
-\item{end_date}{end dtae of desk review}
+\item{end_date}{end date}
 
 \item{mark_x}{whether to put a mark on where AFP cases are less than 5}
 


### PR DESCRIPTION
Previously, maps had used only the most recent shape files when creating maps. However, shape files from the most recent year may be different from the previous year. I revised the mapping functions so that years are now matching up to the correct shapefiles.

To test, run a desk review of Somalia (or any country with shape changes in the past 4 years). Only requirement would be to run the cleaning function for `ctry.data` and to load the spatial files like so:
```
ctry.shape <- load_clean_ctry_sp(ctry_name = Sys.getenv("DR_COUNTRY"), type = "long")
prov.shape <- load_clean_prov_sp(ctry_name = Sys.getenv("DR_COUNTRY"), type = "long")
dist.shape <- load_clean_dist_sp(ctry_name = Sys.getenv("DR_COUNTRY"), type = "long")
```