### PR TITLE
❇️ Add flag for missingness of `age.months` in `f.npafp.rate.01()`

### DIFF
--- a/R/f.npafp.rate.01.R
+++ b/R/f.npafp.rate.01.R
@@ -254,9 +254,6 @@ f.npafp.rate.01 <- function(
     }
   )
 
-  agemonth_summary <- agemonth_summary |>
-    dplyr::filter(prop >= 0.1)
-
   # Get inconsistent GUIDs across temporal scale
   incomplete.adm <- get_incomplete_adm(pop.data, spatial.scale, start.date, end.date)
 
@@ -301,9 +298,12 @@ f.npafp.rate.01 <- function(
   } else {
     if (nrow(agemonth_summary) > 0) {
       cli::cli_alert_warning(paste0(
-        "Proportion of cases missing `age.months` are greater than or equal to 10% ",
+        "Proportion of cases missing `age.months`",
         "for some combinations of ", paste(names.ctry, collapse = ", "),
-        ".\nConsider toggling missing_agemonths = TRUE."
+        " range between ", min(agemonth_summary$prop) * 100, "-",
+        max(agemonth_summary$prop) * 100, "%",
+        ".\nCheck if toggling missing_agemonths = TRUE is warranted.",
+        "\nRun check_missing_rows() on the dataset for specifics on missingness."
       ))
     }
     afp.data <- afp.data |>

--- a/man/f.npafp.rate.01.Rd
+++ b/man/f.npafp.rate.01.Rd
@@ -11,6 +11,7 @@ f.npafp.rate.01(
   end.date,
   spatial.scale,
   pending = T,
+  missing_agemonths = F,
   rolling = F,
   sp_continuity_validation = T
 )
@@ -37,6 +38,8 @@ formatted as \verb{adm(0,1,2)guid}, onset date as \code{date} and \code{cdc.clas
 }}
 
 \item{pending}{\code{bool} Should cases classified as \code{PENDING} or \verb{LAB PENDING} be included in calculations? Default \code{TRUE}.}
+
+\item{missing_agemonths}{\code{bool} Should cases with \code{NA} values for \code{age.months} be included? Default \code{FALSE}.}
 
 \item{rolling}{\code{bool} Should the analysis be performed on a rolling bases? Default \code{FALSE}.}
 


### PR DESCRIPTION
New parameter added called `missing_agemonths`. To test, run `f.npafp.rate.01()` per usual using either `raw.data` or `ctry.data`. 

Closes #169 