### PR TITLE
🐛  Update deprecation message and example for `generate_inad_tab()`

### DIFF
--- a/R/dr.figure.functions.R
+++ b/R/dr.figure.functions.R
@@ -3450,7 +3450,6 @@ generate_pop_tab <- function(prov.case.ind,
 #' ctry.data <- init_dr("algeria")
 #' start_date <- "2021-01-01"
 #' end_date <- "2023-12-31"
-#' stool.data <- generate_stool_data(ctry.data$afp.all.2, "2021-01-01", "2023-12-31")
 #' cstool <- f.stool.ad.01(
 #'   afp.data = ctry.data$afp.all.2,
 #'   admin.data = ctry.data$ctry.pop,
@@ -3462,14 +3461,24 @@ generate_pop_tab <- function(prov.case.ind,
 #'   rolling = F,
 #'   sp_continuity_validation = F
 #' )
-#' generate_inad_tab(ctry.data, stool.data, cstool, start_date, end_date)
+#' generate_inad_tab(ctry.data, cstool, start_date, end_date)
 #' }
 #'
 #' @export
 generate_inad_tab <- function(ctry.data,
                               cstool,
                               start_date,
-                              end_date) {
+                              end_date,
+                              stool.data = lifecycle::deprecated()) {
+
+  if (lifecycle::is_present(stool.data)) {
+    lifecycle::deprecate_warn(
+      when = "1.2.0",
+      what = "generate_inad_tab(stool.data)",
+      details = "The argument is not used in the function body and will be dropped in future releases."
+    )
+  }
+
   start_date <- lubridate::as_date(start_date)
   end_date <- lubridate::as_date(end_date)
 

--- a/man/generate_inad_tab.Rd
+++ b/man/generate_inad_tab.Rd
@@ -4,7 +4,13 @@
 \alias{generate_inad_tab}
 \title{Issues with stool adequacy at the country level}
 \usage{
-generate_inad_tab(ctry.data, cstool, start_date, end_date)
+generate_inad_tab(
+  ctry.data,
+  cstool,
+  start_date,
+  end_date,
+  stool.data = lifecycle::deprecated()
+)
 }
 \arguments{
 \item{ctry.data}{\code{list} large list containing polio data for a country. This is the output of
@@ -27,7 +33,6 @@ Generates a summary table at the country level highlighting issues around stool 
 ctry.data <- init_dr("algeria")
 start_date <- "2021-01-01"
 end_date <- "2023-12-31"
-stool.data <- generate_stool_data(ctry.data$afp.all.2, "2021-01-01", "2023-12-31")
 cstool <- f.stool.ad.01(
   afp.data = ctry.data$afp.all.2,
   admin.data = ctry.data$ctry.pop,
@@ -39,7 +44,7 @@ cstool <- f.stool.ad.01(
   rolling = F,
   sp_continuity_validation = F
 )
-generate_inad_tab(ctry.data, stool.data, cstool, start_date, end_date)
+generate_inad_tab(ctry.data, cstool, start_date, end_date)
 }
 
 }


### PR DESCRIPTION
I actually took out the argument on sirfunction v.1.2.0, but did not update the example or set a deprecation warning.

#Closes 182