### PR TITLE
❇️ Update functions using new color schemes

### DIFF
--- a/R/dr.figure.functions.R
+++ b/R/dr.figure.functions.R
@@ -384,27 +384,8 @@ generate_es_site_det <- function(ctry.data,
 
   colnames(minsy)[colnames(minsy) == "province"] <- "ADM1_NAME"
 
-  default_vaccine_type <- c(
-    "nOPV2" = "blue",
-    "bOPV" = "coral1",
-    "mOPV2" = "purple"
-  )
-
-  default_detections <- c(
-    "No EV isolated" = "#f2f2f2",
-    "NPEV only" = "darkgrey",
-    "VDPV2" = "darkred",
-    "Sabin 1" = scales::brewer_pal(palette = "Set1")(9)[1],
-    "Sabin 2" = scales::brewer_pal(palette = "Set1")(9)[8],
-    "Sabin 1/Sabin 3" = scales::brewer_pal(palette = "Set1")(9)[2],
-    "Sabin 3" = scales::brewer_pal(palette = "Set1")(9)[3],
-    "Sabin 1/Sabin 3/VDPV2" = scales::brewer_pal(palette = "Set1")(9)[4],
-    "Sabin 1/VDPV2" = scales::brewer_pal(palette = "Set1")(9)[5],
-    "Sabin 3/VDPV2" = scales::brewer_pal(palette = "Set1")(9)[6],
-    "Sabin 1 or Sabin 3" = scales::brewer_pal(palette = "Set1")(9)[6],
-    "Sabin 1/3" = scales::brewer_pal(palette = "Set1")(9)[2],
-    "Sabin 1/3 and VDPV2" = scales::brewer_pal(palette = "Set1")(9)[5]
-  )
+  default_vaccine_type <- f.color.schemes("es.vaccine.types")
+  default_detections <- f.color.schemes("es.detections")
 
   if (is.null(vaccine_types)) {
     vaccine_types <- default_vaccine_type

--- a/R/generate_adhoc_map.R
+++ b/R/generate_adhoc_map.R
@@ -486,45 +486,7 @@ set_emergence_colors <- function(raw.data, country, start_date = NULL, end_date 
     dplyr::arrange(.data$emg_grp2) |>
     tidyr::drop_na()
 
-  emg_cols <- c(
-    "ANG-LNO-3" = "#68228b",
-    "BOT-FRA-1" = "#458B74",
-    "CAE-EXT-1" = "#fd8d3c",
-    "CAF-BNG-2" = "#d21404",
-    "CAF-BNG-3" = "#00008b",
-    "ETH-TIG-1" = "#CA5621",
-    "EGY-NOR-1" = "#8B2323",
-    "INO-ACE-1" = "#ED7222",
-    "INO-cVDPV2" = "#458B00",
-    "MAD-ANO-2" = "#B254A5",
-    "MOZ-MAN-1" = "#458B00",
-    "MOZ-NPL-2" = "#008B8b",
-    "NIE-KTS-1" = "#68228b",
-    "NIE-ZAS-1" = "#F5191C",
-    "RDC-BUE-1" = "#8B8B83",
-    "RDC-HKA-2" = "#B14A34",
-    "RDC-KOR-1" = "#104E8B",
-    "RDC-MAN-3" = "#556B2F",
-    "RDC-MAN-5" = "#B5651d",
-    "RDC-cVDPV2" = "#000000",
-    "RDC-SKV-1" = "#8B3A3A",
-    "RDC-TAN-1" = "#CA5621",
-    "RDC-TSH-1" = "#AC6A9F",
-    "RDC-TSH-2" = "#F5191C",
-    "RSS-JON-1" = "#fd8d3c",
-    "RSS-UNL-1" = "#2D7E47",
-    "RSS-WEQ-1" = "#8B8B83",
-    "SOM-BAN-1" = "#891171",
-    "SOM-BAY-1" = "#7C68B3",
-    "SUD-RED-1" = "#F28265",
-    "YEM-TAI-1" = "#4A708B",
-    "ZIM-HRE-1" = "#A03E3F",
-    "YB3A" = "#4A708B",
-    "YB3C" = "#A03E3F",
-    "YB3A4A" = "#AC6A9F",
-    "YB3A4A & YB3A4B" = "#fd8d3c",
-    "YB3A4B" = "#2D7E47"
-  )
+  emg_cols <- f.color.schemes("emergence.groups")
 
   unassigned_emergence <- setdiff(emg$emg_grp2, names(emg_cols))
   if (length(unassigned_emergence) == 0) {


### PR DESCRIPTION
Closes #199 

Just replaced color schemes defined within  `set_emergence_colors()` and `generate_es_site_det()` to use `f.color.schemes()`. This allows us to only need to change the `f.color.schemes()` function for any changes in the color schemes.