### PR TITLE
258 explore edav fix

### DIFF
--- a/R/dal.R
+++ b/R/dal.R
@@ -2227,6 +2227,9 @@ explore_edav <- function(path = get_constant("DEFAULT_EDAV_FOLDER")) {
           pointer <- sub("/$", "", pointer)
           cli::cli_alert_success(paste0("Navigating to: ", pointer))
           break
+        } else if (nrow(output) == 0) {
+          cli::cli_alert_warning("Directory is empty.")
+          break
         }
         cli::cli_alert_info("Please input the line number:")
         response <- stringr::str_trim(readline("Response: "))

--- a/sirfunctions.Rproj
+++ b/sirfunctions.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: e9616991-2fba-4185-b9cb-72e1f1045eb4
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
Navigate to an empty folder on EDAV. When you prompt to select a folder (option 2), it should automatically send a warning that the current folder is empty and there's nothing to navigate to.

To test, call `explore_edav()` and go to `Data/desk_review/empty_folder` and select option 2.