### PR TITLE
❇️ Allow data lake interfacing functions to work on POSIT workbench

### DIFF
--- a/man/explore_edav.Rd
+++ b/man/explore_edav.Rd
@@ -4,10 +4,15 @@
 \alias{explore_edav}
 \title{Interactive loading of EDAV data}
 \usage{
-explore_edav(path = get_constant("DEFAULT_EDAV_FOLDER"))
+explore_edav(
+  path = get_constant("DEFAULT_EDAV_FOLDER"),
+  azcontainer = suppressMessages(get_azure_storage_connection())
+)
 }
 \arguments{
 \item{path}{\code{str} Path to start at initially.}
+
+\item{azcontainer}{Azure storage container provided by \code{\link[=get_azure_storage_connection]{get_azure_storage_connection()}}.}
 }
 \value{
 \code{tibble} Data from the EDAV environment.

--- a/man/get_all_polio_data.Rd
+++ b/man/get_all_polio_data.Rd
@@ -9,7 +9,8 @@ get_all_polio_data(
   folder = "GID/PEB/SIR/Data/",
   force.new.run = F,
   recreate.static.files = F,
-  attach.spatial.data = T
+  attach.spatial.data = T,
+  azcontainer = suppressMessages(get_azure_storage_connection())
 )
 }
 \arguments{
@@ -27,6 +28,8 @@ get_all_polio_data(
 \item{recreate.static.files}{\code{bool} Default \code{FALSE}, if \code{TRUE} will run all data and cache.}
 
 \item{attach.spatial.data}{\code{bool} Default \code{TRUE}, adds spatial data to downloaded object.}
+
+\item{azcontainer}{Azure storage container provided by \code{\link[=get_azure_storage_connection]{get_azure_storage_connection()}}.}
 }
 \value{
 Named \code{list} containing polio data that is relevant to CDC.

--- a/man/get_azure_storage_connection.Rd
+++ b/man/get_azure_storage_connection.Rd
@@ -6,15 +6,23 @@
 \usage{
 get_azure_storage_connection(
   app_id = "04b07795-8ddb-461a-bbee-02f9e1bf7b46",
-  auth = "authorization_code"
+  auth = "authorization_code",
+  ...
 )
 }
 \arguments{
-\item{app_id}{\code{str} Application ID defaults to "04b07795-8ddb-461a-bbee-02f9e1bf7b46",
+\item{app_id}{\code{str} Application ID defaults to \code{"04b07795-8ddb-461a-bbee-02f9e1bf7b46"},
 this can be changed if you have a service principal.}
 
-\item{auth}{\code{str} Authorization type defaults to "authorization_code",
-this can be changed if you have a service principal.}
+\item{auth}{\code{str} Authorization type defaults to \code{"authorization_code"},
+this can be changed if you have a service principal.
+
+Valid values are:\code{"authorization_code"}, \code{"device_code"},
+\code{"client_credentials"}, \code{"resource_owner"}, \code{"on_behalf_of"}.
+
+See \strong{Details} of \code{\link[AzureAuth:get_azure_token]{AzureAuth::get_azure_token()}} for further details.}
+
+\item{...}{additional parameters passed to \code{\link[AzureAuth:get_azure_token]{AzureAuth::get_azure_token()}}.}
 }
 \value{
 Azure container verification


### PR DESCRIPTION
The following functions have been modified:
1. `explore_edav()`
2. `get_azure_storage_connection()`
3. `get_all_polio_data()`

The basic gist of it is that we needed to make `get_azure_storage_connection()` flexible to take a container using the service principal credentials. Then, functions that has calls to `edav_io()` just needs to make sure they take an Azure container in their argument to make them flexible.

To test:
1. Go to Posit workbench and initiate a new session.
5. Clone sirfunctions if you haven't already.
6. Switch to the 274 branch.
7. Run `devtools::load_all()`.
8. On an empty R script, do the following:
```
# use the service principal ID and secret keys
container <- get_azure_storage_connection(auth = NULL,
                                          app_id = "",
                                          password = "")
raw.data <- get_all_polio_data(azcontainer = container)
explore_edav (azcontainer = container)
edav_io("read", file_loc = "Sandbox/raw_data_2025-02-14.rds", azcontainer = container)
```