### PR TITLE
❇️ Add examples for f.npafp.rate.01()

### DIFF
--- a/R/f.npafp.rate.01.R
+++ b/R/f.npafp.rate.01.R
@@ -185,6 +185,12 @@ npafp_rolling <- function(afp.data, year.pop.data, start_date, end_date, spatial
 #' @param sp_continuity_validation `bool` Should we filter places that are not present
 #' for the entirety of the analysis dates? Default `TRUE`.
 #' @returns `tibble` A table containing NPAFP rates as well as additional information relevant to each location analyzed.
+#' @examples
+#' \dontrun{
+#' raw.data <- get_all_polio_data()
+#' npafp_ctry <- f.npafp.rate.01(raw.data$afp, raw.data$ctry.pop, "2022-01-01", "2024-12-31", "ctry")
+#' }
+#'
 #' @export
 f.npafp.rate.01 <- function(
     afp.data,

--- a/R/f.stool.ad.01.R
+++ b/R/f.stool.ad.01.R
@@ -356,12 +356,14 @@ get_incomplete_adm <- function(admin_data, spatial_scale, start_date, end_date) 
 #' @param admin.data `tibble` Population data. Renamed in favor of `pop.data`.
 #' @returns `tibble` Long format stool adequacy evaluations.
 #' @examples
+#' \dontrun{
 #' raw.data <- get_all_polio_data()
 #' stool.ads <- f.stool.ad.01(raw.data$afp, raw.data$ctry.pop,
 #'   "2021-01-01", "2023-12-31",
 #'   "ctry",
 #'   sp_continuity_validation = FALSE
 #' )
+#' }
 #'
 #' @export
 f.stool.ad.01 <- function(

--- a/R/f.timely.detection.01.R
+++ b/R/f.timely.detection.01.R
@@ -18,6 +18,8 @@
 #' @returns `list` A list with two `tibble`s with global and sub-global
 #' AFP / ES detection timeliness evaluation.
 #' @examples
+#' \dontrun{
+#'
 #' raw.data <- get_all_polio_data()
 #' ctry.data <- extract_country_data("algeria", raw.data)
 #' ctry.seq <- get_lab_locs()
@@ -29,6 +31,7 @@
 #'   ctry.data$afp.all.2, ctry.data$es, ctry.seq,
 #'   "2021-01-01", "2023-12-31"
 #' )
+#' }
 #'
 #' @export
 

--- a/man/f.npafp.rate.01.Rd
+++ b/man/f.npafp.rate.01.Rd
@@ -55,3 +55,10 @@ for the entirety of the analysis dates? Default \code{TRUE}.}
 Calculate the NPAFP rate from POLIS data. Can either pass \code{raw.data} to calculate NPAFP rates
 on the global dataset, or a \code{ctry.data} dataset.
 }
+\examples{
+\dontrun{
+raw.data <- get_all_polio_data()
+npafp_ctry <- f.npafp.rate.01(raw.data$afp, raw.data$ctry.pop, "2022-01-01", "2024-12-31", "ctry")
+}
+
+}

--- a/man/f.stool.ad.01.Rd
+++ b/man/f.stool.ad.01.Rd
@@ -63,11 +63,13 @@ missing data is treated. \code{"good"} classifies missing data as good quality
 excludes missing from the calculations.
 }
 \examples{
+\dontrun{
 raw.data <- get_all_polio_data()
 stool.ads <- f.stool.ad.01(raw.data$afp, raw.data$ctry.pop,
   "2021-01-01", "2023-12-31",
   "ctry",
   sp_continuity_validation = FALSE
 )
+}
 
 }

--- a/man/f.timely.detection.01.Rd
+++ b/man/f.timely.detection.01.Rd
@@ -43,6 +43,8 @@ AFP / ES detection timeliness evaluation.
 Calculates the overall timeliness of detection in AFP & ES POLIS data.
 }
 \examples{
+\dontrun{
+
 raw.data <- get_all_polio_data()
 ctry.data <- extract_country_data("algeria", raw.data)
 ctry.seq <- get_lab_locs()
@@ -54,5 +56,6 @@ ctry.summary <- f.timely.detection.01(
   ctry.data$afp.all.2, ctry.data$es, ctry.seq,
   "2021-01-01", "2023-12-31"
 )
+}
 
 }


### PR DESCRIPTION
`f.npafp.rate.01()` didn't have an example before. It looks like the other core functions already had examples, so it was the only function missing one.