### PR TITLE
❇️ Add ability to read and write parquet files from edav io

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Imports:
     withr,
     yaml
 Suggests:
+    arrow,
     blastula,
     forcats,
     ggspatial,

--- a/R/dal.R
+++ b/R/dal.R
@@ -487,13 +487,17 @@ edav_io <- function(
   }
 
   if (io == "write") {
-    if (!grepl(".rds$|.csv$|.xlsx$|.xls$|.png$|.jpg$|.jpeg$|.parquet$", file_loc)) {
+    if (!grepl(".rds$|.rda$|.csv$|.xlsx$|.xls$|.png$|.jpg$|.jpeg$|.parquet$", file_loc)) {
       cli::cli_abort(paste0("Please pass a path including the file name in file_loc.",
                             " (i.e., folder/data.csv)"))
     }
 
     if (endsWith(file_loc, ".rds")) {
       AzureStor::storage_save_rds(object = obj, container = azcontainer, file = file_loc)
+    }
+
+    if (endsWith(file_loc, ".rda")) {
+      AzureStor::storage_save_rdata(object = obj, container = azcontainer, file = file_loc)
     }
 
     if (endsWith(file_loc, ".csv")) {

--- a/R/dal.R
+++ b/R/dal.R
@@ -234,8 +234,8 @@ sirfunctions_io <- function(
         file_loc, azcontainer = azcontainer
       ))
     } else {
-      if (!grepl(".rds$|.rda$|.csv$|.xlsx$|.xls$", file_loc)) {
-        stop("At the moment only 'rds' 'rda' 'csv' 'xlsx' and 'xls' are supported for reading.")
+      if (!grepl(".rds$|.rda$|.csv$|.xlsx$|.xls$|.parquet$", file_loc)) {
+        stop("At the moment only 'rds' 'rda' 'csv' 'xlsx', 'xls', 'parquet' are supported for reading.")
       }
 
       if (endsWith(file_loc, ".rds")) {
@@ -246,6 +246,8 @@ sirfunctions_io <- function(
         return(readr::read_csv(file_loc))
       } else if (endsWith(file_loc, ".xlsx") | endsWith(file_loc, ".xls")) {
         return(read_excel_from_edav(src = file_loc, ...))
+      } else if (endsWith(file_loc, ".parquet")) {
+        return(arrow::read_parquet(file_loc))
       }
     }
   }
@@ -268,6 +270,8 @@ sirfunctions_io <- function(
         readr::write_csv(x = obj, file = file_loc)
       } else if (endsWith(file_loc, ".xlsx") | endsWith(file_loc, ".xls")) {
         writexl::write_xlsx(obj, path = file_loc)
+      } else if (endsWith(file_loc, ".parquet")) {
+        arrow::write_parquet(obj, file_loc)
       }
     }
   }

--- a/R/dal.R
+++ b/R/dal.R
@@ -260,8 +260,8 @@ sirfunctions_io <- function(
     if (edav) {
       edav_io(io = "write", NULL, file_loc = file_loc, obj = obj, azcontainer = azcontainer)
     } else {
-      if (!grepl(".rds$|.rda$|.csv$", file_loc)) {
-        stop("At the moment only 'rds' 'rda' 'csv' 'xlsx' and 'xls' are supported for reading.")
+      if (!grepl(".rds$|.rda$|.csv$|.xlsx$|.xls$|.parquet$", file_loc)) {
+        stop("At the moment only 'rds' 'rda' 'csv' 'xlsx', 'xls' and 'parquet' are supported for reading.")
       } else if (endsWith(file_loc, ".rds")) {
         readr::write_rds(x = obj, file = file_loc)
       } else if (endsWith(file_loc, ".rda")) {
@@ -271,7 +271,7 @@ sirfunctions_io <- function(
       } else if (endsWith(file_loc, ".xlsx") | endsWith(file_loc, ".xls")) {
         writexl::write_xlsx(obj, path = file_loc)
       } else if (endsWith(file_loc, ".parquet")) {
-        arrow::write_parquet(obj, file_loc)
+        arrow::write_parquet(obj, sink = file_loc)
       }
     }
   }

--- a/R/sirfunctions-package.R
+++ b/R/sirfunctions-package.R
@@ -209,7 +209,7 @@ utils::globalVariables(c(
   "country_name", "vpd", "variable", "iso3_code", "vpd_short_name",
 
   # From sirfunctions_io()
-  "isdir", "lastModified"
+  "isdir", "lastModified", "mtime", "uid"
 
 
 ))


### PR DESCRIPTION
Note: must download arrow package first before testing.

To test, use the typical edav_io read and write functionalities. You can read the example iris parquet dataset located in Sandbox/iris.parquet. 

Also, test out sirfunctions_io() to make sure it works as intended. To test:
1. sirfunctions_io("write", NULL, file_loc = "path/to/downloads/folder/iris.parquet", obj = iris, edav = F)
2. sirfunctions_io("read", NULL, file_loc = "path/to/downloads/folder/iris.parquet", obj = iris, edav = F)