### PR TITLE
❇️  315 make archiving optional in get_all_polio_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ rsconnect/
 #files 
 R/nish_sandbox.R
 inst/doc
+.DS_Store

--- a/R/dal.R
+++ b/R/dal.R
@@ -797,10 +797,6 @@ if (recreate.static.files) {
   create.cache <- T
 }
 
-if (!archive) {
-  create.cache <- FALSE
-}
-
 if (!force.new.run) {
   # determine all raw data files to be downloaded
   if (use_edav) {
@@ -3231,19 +3227,19 @@ create_polis_data_folder <- function(data_folder, polis_folder,
   if (!sirfunctions_io("exists.dir", NULL, file.path(data_folder, "polis", "archive"), edav = use_edav)) {
     sirfunctions_io("create.dir", NULL, file.path(data_folder, "polis", "archive"), edav = use_edav)
   }
-  # Move previous files to archive in polis data folder
 
-  # Explicitly create since Sys.Date() could potentially vary when ran overnight
+  current.table <- sirfunctions_io(io = "list", NULL,
+                                   file.path(data_folder, "polis"),
+                                   edav = use_edav) |>
+                                    dplyr::filter(isdir != TRUE)
+
+# Move previous files to archive in polis data folder
 if (archive) {
+   # Explicitly create since Sys.Date() could potentially vary when ran overnight
   archive_folder_name <- Sys.Date()
   sirfunctions_io("create.dir", NULL,
                   file.path(data_folder, "polis", "archive", archive_folder_name),
                   edav = use_edav)
-
-  current.table <- sirfunctions_io(io = "list", NULL,
-                                 file.path(data_folder, "polis"),
-                                 edav = use_edav) |>
-    dplyr::filter(isdir != TRUE)
 
   if (nrow(current.table) == 0) {
     cli::cli_alert_success("No data to archive")
@@ -3305,13 +3301,12 @@ if (archive && is.finite(keep_n_archives)) {
 
   cli::cli_process_start("Adding updated data to polis data folder")
 
-  # Delete previous files
-  if (nrow(current.table) != 0) {
-    lapply(1:nrow(current.table), \(i) {
-      sirfunctions_io("delete", NULL,
-                      current.table$src_path[i], edav = use_edav)
-    })
-  }
+# Delete previous files
+if (nrow(current.table) != 0) {
+  lapply(1:nrow(current.table), \(i) {
+    sirfunctions_io("delete", NULL, current.table$src_path[i], edav = use_edav)
+  })
+}
 
   # Move all files to core polis data folder
   lapply(1:nrow(source.table), function(i){

--- a/R/dal.R
+++ b/R/dal.R
@@ -3196,7 +3196,7 @@ read_excel_from_edav <- function(src, ...) {
 #'
 create_polis_data_folder <- function(data_folder, polis_folder,
                                     core_ready_folder, use_edav,
-                                    archive = TRUE, keep_n_archives = 3) {
+                                    archive = TRUE, keep_n_archives = Inf) {
 
   files <- c("afp_linelist_2001-01-01",
              "afp_linelist_2019-01-01",

--- a/R/dal.R
+++ b/R/dal.R
@@ -2184,7 +2184,7 @@ load_clean_dist_sp <- function(azcontainer = suppressMessages(get_azure_storage_
 
   if (!is.null(type) && type == "long") {
     df.list <- lapply(st_year:end_year, function(i) f.yrs.01(out, i))
-    out <- do.call(rbind, df.list)
+    out <- dplyr::bind_rows(df.list)
   }
 
   return(out)
@@ -2312,7 +2312,7 @@ load_clean_prov_sp <- function(azcontainer = suppressMessages(get_azure_storage_
 
   if (!is.null(type) && type == "long") {
     df.list <- lapply(st_year:end_year, function(i) f.yrs.01(out, i))
-    out <- do.call(rbind, df.list)
+    out <- dplyr::bind_rows(df.list)
   }
 
   return(out)
@@ -2429,7 +2429,7 @@ load_clean_ctry_sp <- function(azcontainer = suppressMessages(get_azure_storage_
 
   if (!is.null(type) && type == "long") {
     df.list <- lapply(st_year:end_year, function(i) f.yrs.01(out, i))
-    out <- do.call(rbind, df.list)
+    out <- dplyr::bind_rows(df.list)
   }
 
   return(out)

--- a/R/dal.R
+++ b/R/dal.R
@@ -3279,7 +3279,7 @@ if (archive) {
 }
 
 # handle number of archives to keep
-if (archive && is.finite(keep_n_archives)) {
+if (archive & is.finite(keep_n_archives)) {
 
   # Obtain archive folders
   archive_dirs <- sirfunctions_io("list", NULL, file.path(data_folder, "polis", "archive"),

--- a/R/dal.R
+++ b/R/dal.R
@@ -298,7 +298,7 @@ sirfunctions_io <- function(
       edav_io(io = "delete.dir", NULL, force_delete = T, azcontainer = azcontainer,
               file_loc = file_loc)
     } else {
-      unlink(file_loc, recursive = TRUE)
+      unlink(file_loc, recursive = TRUE, force = TRUE)
     }
   }
 

--- a/R/dal.R
+++ b/R/dal.R
@@ -527,7 +527,7 @@ edav_io <- function(
     }
 
     if (force_delete) {
-      AzureStor::delete_storage_file(azcontainer, file_loc, confirm = F, recursive = TRUE)
+      AzureStor::delete_storage_file(azcontainer, file_loc, confirm = F)
     } else {
       x <- readline(prompt = "Are you sure you want to delete this folder? It can only be recovered by an administrator. [Y/N]")
       x <- tolower(x)
@@ -535,7 +535,7 @@ edav_io <- function(
 
       if (grepl("y|n", x)) {
         if (x == "y") {
-          AzureStor::delete_storage_file(azcontainer, file_loc, confirm = F, recursive = TRUE)
+          AzureStor::delete_storage_file(azcontainer, file_loc, confirm = F)
           cli::cli_alert_info("File deleted!")
         } else {
           cli::cli_alert_info("Deletion canceled.")

--- a/R/dal.R
+++ b/R/dal.R
@@ -3211,7 +3211,7 @@ create_polis_data_folder <- function(data_folder, polis_folder,
              "sia_2000")
 
   if (!sirfunctions_io("exists.dir", NULL,
-                      file.path(polis_folder, "data", "Core_Ready_Files"),
+                      file.path(polis_folder, "data", core_ready_folder),
                       edav = use_edav)) {
     cli::cli_abort("Core Ready folder not found in the POLIS folder. Please run preprocessing and try again.")
   }

--- a/R/dal.R
+++ b/R/dal.R
@@ -3262,7 +3262,6 @@ create_polis_data_folder <- function(data_folder, polis_folder,
     dplyr::select(name, src_path, dest_path)
 
   # Archive previous versions in the core polis data folder
-  cli::cli_process_start("Archiving previous data in the polis folder")
   if (!sirfunctions_io("exists.dir", NULL, file.path(data_folder, "polis", "archive"), edav = use_edav)) {
     sirfunctions_io("create.dir", NULL, file.path(data_folder, "polis", "archive"), edav = use_edav)
   }
@@ -3282,6 +3281,7 @@ create_polis_data_folder <- function(data_folder, polis_folder,
 
 # Move previous files to archive in polis data folder
 if (archive) {
+  cli::cli_process_start("Archiving previous data in the polis folder")
    # Explicitly create since Sys.Date() could potentially vary when ran overnight
   archive_folder_name <- Sys.Date()
   sirfunctions_io("create.dir", NULL,

--- a/R/dal.R
+++ b/R/dal.R
@@ -3324,7 +3324,7 @@ if (archive & is.finite(keep_n_archives)) {
   archive_dirs <- sirfunctions_io("list", NULL, file.path(data_folder, "polis", "archive"),
                                   edav = use_edav) |>
     dplyr::mutate(date = lubridate::as_date(basename(name))) |>
-    dplyr::arrange(dplyr::desc(lastModified))
+    dplyr::arrange(dplyr::desc(date))
 
   if (nrow(archive_dirs) > keep_n_archives) {
     dirs_to_remove <- archive_dirs[(keep_n_archives + 1):nrow(archive_dirs), ]

--- a/R/dal.R
+++ b/R/dal.R
@@ -730,7 +730,7 @@ get_all_polio_data <- function(
     attach.spatial.data = T,
     use_edav = TRUE,
     archive = TRUE,
-    keep_n_archives = 3) {
+    keep_n_archives = Inf) {
 
   # check to see that size parameter is appropriate
   if (!size %in% c("small", "medium", "large")) {

--- a/man/create_polis_data_folder.Rd
+++ b/man/create_polis_data_folder.Rd
@@ -10,7 +10,7 @@ create_polis_data_folder(
   core_ready_folder,
   use_edav,
   archive = TRUE,
-  keep_n_archives = 3
+  keep_n_archives = Inf
 )
 }
 \arguments{

--- a/man/create_polis_data_folder.Rd
+++ b/man/create_polis_data_folder.Rd
@@ -8,7 +8,9 @@ create_polis_data_folder(
   data_folder,
   polis_folder,
   core_ready_folder,
-  use_edav
+  use_edav,
+  archive = TRUE,
+  keep_n_archives = 3
 )
 }
 \arguments{
@@ -19,6 +21,13 @@ create_polis_data_folder(
 \item{core_ready_folder}{\code{str} Which core ready folder to use. Defaults to \code{"Core_Ready_Files"}.}
 
 \item{use_edav}{\code{bool} Are file paths on EDAV?}
+
+\item{archive}{Logical. Whether to archive previous output directories
+before overwriting. Default is \code{TRUE}.}
+
+\item{keep_n_archives}{Numeric. Number of archive folders to retain.
+Defaults to \code{Inf}, which keeps all archives. Set to a finite number
+(e.g., 3) to automatically delete older archives beyond the N most recent.}
 }
 \description{
 Copies the updated POLIS data into the data folder. This function is used

--- a/man/edav_io.Rd
+++ b/man/edav_io.Rd
@@ -28,6 +28,7 @@ of interest. See examples.
 \item \code{"list"} Returns a tibble with all objects in a folder.
 \item \code{"upload"} Moves a file of any type to EDAV.
 \item \code{"delete"} Deletes a file.
+\item \code{"delete.dir"} Deletes a folder.
 }}
 
 \item{default_dir}{\code{str} The default directory in EDAV. \code{"GID/PEB/SIR"} is the default directory

--- a/man/get_all_polio_data.Rd
+++ b/man/get_all_polio_data.Rd
@@ -14,7 +14,7 @@ get_all_polio_data(
   attach.spatial.data = T,
   use_edav = TRUE,
   archive = TRUE,
-  keep_n_archives = 3
+  keep_n_archives = Inf
 )
 }
 \arguments{

--- a/man/get_all_polio_data.Rd
+++ b/man/get_all_polio_data.Rd
@@ -12,7 +12,9 @@ get_all_polio_data(
   force.new.run = F,
   recreate.static.files = F,
   attach.spatial.data = T,
-  use_edav = TRUE
+  use_edav = TRUE,
+  archive = TRUE,
+  keep_n_archives = 3
 )
 }
 \arguments{
@@ -37,6 +39,13 @@ spatial files, coverage data, and population data. Defaults to \code{"GID/PEB/SI
 \item{attach.spatial.data}{\code{bool} Default \code{TRUE}, adds spatial data to downloaded object.}
 
 \item{use_edav}{\code{bool} Build raw data list using EDAV files. Defaults to \code{TRUE}.}
+
+\item{archive}{Logical. Whether to archive previous output directories
+before overwriting. Default is \code{TRUE}.}
+
+\item{keep_n_archives}{Numeric. Number of archive folders to retain.
+Defaults to \code{Inf}, which keeps all archives. Set to a finite number
+(e.g., 3) to automatically delete older archives beyond the N most recent.}
 }
 \value{
 Named \code{list} containing polio data that is relevant to CDC.


### PR DESCRIPTION
This PR adds `archive` and `keep_n_archives` arguments to `get_all_polio_data()`, like in `tidypolis::preprocess_cdc()`.

This helps avoid saving large files when running locally.

Closes #315 