### PR TITLE
318 performance issue in long format output of shapefile loading and cleaning functions

### DIFF
--- a/R/dal.R
+++ b/R/dal.R
@@ -2123,7 +2123,7 @@ load_clean_dist_sp <- function(azcontainer = suppressMessages(get_azure_storage_
 
   if (!is.null(type) && type == "long") {
     df.list <- lapply(st_year:end_year, function(i) f.yrs.01(out, i))
-    out <- do.call(rbind, df.list)
+    out <- dplyr::bind_rows(df.list)
   }
 
   return(out)
@@ -2251,7 +2251,7 @@ load_clean_prov_sp <- function(azcontainer = suppressMessages(get_azure_storage_
 
   if (!is.null(type) && type == "long") {
     df.list <- lapply(st_year:end_year, function(i) f.yrs.01(out, i))
-    out <- do.call(rbind, df.list)
+    out <- dplyr::bind_rows(df.list)
   }
 
   return(out)
@@ -2368,7 +2368,7 @@ load_clean_ctry_sp <- function(azcontainer = suppressMessages(get_azure_storage_
 
   if (!is.null(type) && type == "long") {
     df.list <- lapply(st_year:end_year, function(i) f.yrs.01(out, i))
-    out <- do.call(rbind, df.list)
+    out <- dplyr::bind_rows(df.list)
   }
 
   return(out)


### PR DESCRIPTION
In looking for low-hanging fruits to optimize speed in `load_clean_dist_sp()`, I noticed that when benchmarking the long format output, the bottleneck occurs at the final step of the function, where the list of shapefiles is bound together.

Currently we use base R’s `do.call(rbind, df.list)`, which is 6–7× slower than `dplyr::bind_rows(df.list)` based on benchmarking.


```
Unit: seconds
       expr       min       lq     mean    median        uq      max neval
 rbind_base 48.390169 48.43066 49.57190 48.471159 50.162770 51.85438     3
  bind_rows  7.544493  7.55576  7.62681  7.567027  7.667969  7.76891     3
```

If you wanted to reproduce this, then try this at the end of `load_clean_dist_sp()` before the row binding section:

```
microbenchmark::microbenchmark(
  rbind_base = {
    df.list <- lapply(st_year:end_year, function(i) f.yrs.01(out, i))
    out1 <- do.call(rbind, df.list)
  },
  
  bind_rows = {
    df.list <- lapply(st_year:end_year, function(i) f.yrs.01(out, i))
    out2 <- dplyr::bind_rows(df.list)
  },
  
  times = 3
)
```

I have implemented the usage of `dplyr::bind_rows` in the shapefile loading and cleaning functions.

Closes #318 