### PR TITLE
🐛 Make EDAV connections work in Posit Connect

### DIFF
--- a/R/dal.R
+++ b/R/dal.R
@@ -59,6 +59,8 @@ get_azure_storage_connection <- function(
       password = creds$pw,
       ...
     )
+    cli::cli_alert_success("Posit Workbench token obtained!")
+    cli::cli_alert_info(paste0("Auth type: ", mytoken$auth_type))
   } else {
     mytoken <- AzureAuth::get_azure_token(
       resource = "https://storage.azure.com/",
@@ -71,6 +73,10 @@ get_azure_storage_connection <- function(
 
   cached_tokens <- AzureAuth::list_azure_tokens()
   token_hash_names <- AzureAuth::list_azure_tokens() |> names()
+
+  if (length(token_hash_names) == 0) {
+    cli::cli_alert_danger("No cached tokens detected!")
+  }
 
   mytoken <- lapply(1:length(token_hash_names), function(x) {
     dplyr::tibble(

--- a/R/dal.R
+++ b/R/dal.R
@@ -59,8 +59,11 @@ get_azure_storage_connection <- function(
       password = creds$pw,
       ...
     )
-    cli::cli_alert_success("Posit Workbench token obtained!")
-    cli::cli_alert_info(paste0("Auth type: ", mytoken$auth_type))
+
+    endptoken <- AzureStor::storage_endpoint(endpoint = "https://davsynapseanalyticsdev.dfs.core.windows.net", token = mytoken)
+    azcontainer <- AzureStor::storage_container(endptoken, "ddphsis-cgh")
+    return(azcontainer)
+
   } else {
     mytoken <- AzureAuth::get_azure_token(
       resource = "https://storage.azure.com/",

--- a/R/dal.R
+++ b/R/dal.R
@@ -33,7 +33,8 @@ get_azure_storage_connection <- function(
     posit_yaml_path = NULL,
     ...) {
 
-  if (stringr::str_starts(Sys.getenv("SF_PARTNER"), "posit_workbench")) {
+  if (stringr::str_starts(Sys.getenv("SF_PARTNER"), "posit_workbench") |
+      stringr::str_starts(Sys.getenv("SF_PARTNER"), "posit_connect")) {
     if (is.null(posit_yaml_path)) {
       creds_path <- "~/credentials/posit_workbench_creds.yaml"
     } else {

--- a/R/dal.R
+++ b/R/dal.R
@@ -33,13 +33,23 @@ get_azure_storage_connection <- function(
     posit_yaml_path = NULL,
     ...) {
 
-  if (stringr::str_starts(Sys.getenv("SF_PARTNER"), "posit_workbench") |
-      stringr::str_starts(Sys.getenv("SF_PARTNER"), "posit_connect")) {
+  if (stringr::str_starts(Sys.getenv("SF_PARTNER"), "posit_workbench")) {
     if (is.null(posit_yaml_path)) {
       creds_path <- "~/credentials/posit_workbench_creds.yaml"
     } else {
       creds_path <- posit_yaml_path
     }
+    creds <- yaml::read_yaml(creds_path)
+    mytoken <- AzureAuth::get_azure_token(
+      resource = "https://storage.azure.com/",
+      tenant = "9ce70869-60db-44fd-abe8-d2767077fc8f",
+      app = creds$app_id,
+      auth_type = NULL,
+      password = creds$pw,
+      ...
+    )
+  } else if (stringr::str_starts(Sys.getenv("SF_PARTNER"), "posit_connect")) {
+    creds_path <- "posit_workbench_creds.yaml"
     creds <- yaml::read_yaml(creds_path)
     mytoken <- AzureAuth::get_azure_token(
       resource = "https://storage.azure.com/",


### PR DESCRIPTION
Posit Connect doesn't work exactly like Posit Workbench. I had to make sure that a copy of the creds YAML file is located inside the Quarto project folder, since Quarto is unable to locate files outside of the project folder. I modified `get_azure_storage_connection()` so that it uses the correct name of `SF_PARTNER` and get rid of the reliance of pulling the token from the cache. Since we are using client credentials anyway, there isn't a need to look at the token cache.

I suspect that accessing the token cache doesn't work because it is located outside the Quarto project folder. But with this change, we can finally schedule jobs in Posit Connect, make Shiny apps using our data, even create automated reports using our global polio dataset! Here's the image:

<img width="1219" height="801" alt="image" src="https://github.com/user-attachments/assets/18976ac6-841b-437a-a930-2ee150e565ee" />

If you'd like to test it, you'll need to have both Posit Workbench and Posit Connect. Then:
1. Create a Quarto R project in Posit workbench.
2. Install sirfunctions, with the 337 branch.
3. Modify the quarto file with the same name as the project.
4. Run test_EDAV_connection()