### PR TITLE
Convert year to factor in case number generation

### DIFF
--- a/R/dr.figure.functions.R
+++ b/R/dr.figure.functions.R
@@ -731,6 +731,7 @@ generate_case_num_dose_g <- function(ctry.data,
       cdc.classification.all2 == "NPAFP",
       dplyr::between(age.months, 6, 59)
     ) |>
+    dplyr::mutate(year = factor(year)) |>
     dplyr::group_by(dose.cat, year, prov) |>
     dplyr::summarise(freq = dplyr::n())
 


### PR DESCRIPTION
Added a mutate step to convert the 'year' column to a factor in the generate_case_num_dose_g function. This ensures proper grouping and summarization by year.