### PR TITLE
Fix variable references in generate_es_site_det

### DIFF
--- a/R/dr.figure.functions.R
+++ b/R/dr.figure.functions.R
@@ -469,8 +469,8 @@ generate_es_site_det <- function(sia.data,
     unique() |>
     dplyr::pull()
 
-  miss_vaccine <- minsy_vaccine_types[!(minsy_vaccine_types %in% names(default_vaccine_type))]
-  miss_dets <- es.data_all_dets[!(es.data_all_dets %in% names(default_detections))]
+  miss_vaccine <- minsy_vaccine_types[!(minsy_vaccine_types %in% names(vaccine_types))]
+  miss_dets <- es.data_all_dets[!(es.data_all_dets %in% names(detection_types))]
 
 
   if (length(miss_vaccine > 0)) {
@@ -492,7 +492,7 @@ generate_es_site_det <- function(sia.data,
     )
 
     cli::cli_alert_warning(warning_message)
-    print(miss_vaccine)
+    print(miss_dets)
   }
 
 


### PR DESCRIPTION
Corrected variable names from default_vaccine_type and default_detections to vaccine_types and detection_types, respectively, in the generate_es_site_det function. Also fixed print statement to display missing detections instead of missing vaccines.