### PR TITLE
Inconsistent loading of files in temporary directory

### DIFF
--- a/R/dal.R
+++ b/R/dal.R
@@ -373,7 +373,7 @@ sirfunctions_io <- function(
 #' @param force_delete `logical` Use delete io without verification in the command line.
 #' @param local_path `str` Local file pathway to upload a file to EDAV. Default is `NULL`.
 #' This parameter is only required when passing `"upload"` in the `io` parameter.
-#' @param ... Optional parameters that work with [readr::read_delim()] or [readxl::read_excel()].
+#' @param ... Optional parameters that work with [readr::read_delim()], [readxl::read_excel()], or [ggplot2::ggsave()].
 #' @returns Output dependent on argument passed in the `io` parameter.
 #' @examples
 #' \dontrun{

--- a/man/edav_io.Rd
+++ b/man/edav_io.Rd
@@ -46,7 +46,7 @@ the information in \code{default_dir} if you set that parameter to \code{NULL}.}
 \item{local_path}{\code{str} Local file pathway to upload a file to EDAV. Default is \code{NULL}.
 This parameter is only required when passing \code{"upload"} in the \code{io} parameter.}
 
-\item{...}{Optional parameters that work with \code{\link[readr:read_delim]{readr::read_delim()}} or \code{\link[readxl:read_excel]{readxl::read_excel()}}.}
+\item{...}{Optional parameters that work with \code{\link[readr:read_delim]{readr::read_delim()}}, \code{\link[readxl:read_excel]{readxl::read_excel()}}, or \code{\link[ggplot2:ggsave]{ggplot2::ggsave()}}.}
 }
 \value{
 Output dependent on argument passed in the \code{io} parameter.


### PR DESCRIPTION
Use `withr` for reading and writing objects to EDAV via `edav_io()`. This prevents issues related to temporary files that are unable to be overwritten, as well as automate the clean up of the temporary file directory.

Closes #406 