### PR TITLE
Update kpi.main.functions.R

### DIFF
--- a/R/kpi.main.functions.R
+++ b/R/kpi.main.functions.R
@@ -219,7 +219,8 @@ get_ctry_abbrev <- function(afp_data) {
       !(place.admin.0 == "INDIA" & ctry.short == "PAK"),
       !(place.admin.0 == "PAKISTAN" & ctry.short == "IND"),
       !(place.admin.0 == "ZAMBIA" & ctry.short == "TAN"),
-      !(place.admin.0 == "PARAGUAY" & ctry.short == "TTO")
+      !(place.admin.0 == "PARAGUAY" & ctry.short == "TTO"),
+      !(place.admin.0 == "MADAGASCAR" & ctry.short == "MAN")
     ) |>
     dplyr::mutate(ctry.short = dplyr::case_when(
       ctry.short == "IND" & place.admin.0 == "INDONESIA" ~ "IDN",


### PR DESCRIPTION
Added manual code to account for a mistyped Madagascar epid in function `get_ctry_abbrev()`. That function creates country abbreviations by grabbing the first 3 letters of epids. When epids are enterred incorrectly, multiple country codes are created and there is manual R code in the function to remove the incorrect country code. For this, I added the following to remove the incorrect Madagascar code:
`!(place.admin.0 == "MADAGASCAR" & ctry.short == "MAN")`

This closes issue #449.

To test, run necessary code to try to get the country codes and also try to run a function that uses it: 


```
raw_data <- get_all_polio_data()

afp_data <- raw_data$afp

c1 <- generate_c1_table(raw_data, "2024-01-01", "2025-12-31")

get_ctry_abbrev(afp_data)

# first change your user id instead of ABC1, or a path you choose
generate_kpi_npafp_bar (c1, afp_data = afp_data, output_path = "C:/Users/ABC1/Downloads")
```

