### PR TITLE
Update kpi.table.functions.R to address filtering out bad guids in ES

### DIFF
--- a/R/kpi.table.functions.R
+++ b/R/kpi.table.functions.R
@@ -853,10 +853,6 @@ generate_c1_table <- function(raw_data, start_date, end_date,
     ) |>
     dplyr::left_join(dist_lookup_table) |>
     dplyr::mutate(whoregion = get_region(ctry)) |>
-    # invalid GUIDS will have consistnet_guid = FALSE while
-    # valid ones will be NA
-    dplyr::left_join(inconsistent_guids) |>
-    dplyr::filter(is.na(consistent_guid)) |>
     dplyr::group_by(
       year_label, rolling_period,
       analysis_year_start, analysis_year_end,


### PR DESCRIPTION
This change removes the inconsistent guid filter on environmental sample df in `generate_c1_table` per team lead request. 

To test this, review the code change in file kpi.table.functions and check `c1 <- generate_c1_table()` with the appropriate parameters as below.

```
raw_data <- get_all_polio_data()
start_date <- "2024-06-01"
end_date <- "2026-05-31"
c1 <- generate_c1_table(raw_data, start_date, end_date)
```

 After running, Chad should have ES sites for both Year 1 and Year 2.

Close #461 