### PR TITLE
465 need temporary quick fix to make code usable with new files

### DIFF
--- a/R/dr.lab.functions.R
+++ b/R/dr.lab.functions.R
@@ -1216,11 +1216,15 @@ clean_lab_data <- function(lab_data, start_date, end_date,
   #list of labs that sent samples to CDC for sequencing prior to February 2025, Nigeria and Uganda started doing their own sequencing.
   #Adding in redundancy for Nigeria in case lines above get deleted, lab locs file gets changed
   lab_data_man <- lab_data |>
-    dplyr::mutate(seq.lab = dplyr::case_when(DateStoolCollected < as_date("2025-02-01") & culture.itd.lab %in% c("Cameroon","KEMRI-Kenya","IBADAN-Nigeria","Ibadan-Nigeria","Nigeria","Senegal","Ethiopia","Oman/Jordan") ~ "CDC-Atlanta",
-                                             DateStoolCollected < as_date("2025-02-01") & country == "UGANDA" ~ "Noguchi-Ghana",
-                                             .default = seq.lab),
-                  seq.cat = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected < as_date("2025-02-01"), "Shipped for sequencing", seq.cat),
-                  seq.capacity = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected < as_date("2025-02-01"), "No sequencing capacity", seq.capacity))
+    dplyr::mutate(
+      seq.lab = dplyr::case_when(
+        # labs that previously shipped to Atlanta for sequencing
+        DateStoolCollected < as_date("2025-02-01") & culture.itd.lab %in% c("Cameroon","KEMRI-Kenya","IBADAN-Nigeria","Ibadan-Nigeria","Nigeria","Senegal","Ethiopia","Oman/Jordan") ~ "CDC-Atlanta",
+        # lab that used to sequence Uganda before UVRI was accredited
+        DateStoolCollected < as_date("2025-02-01") & country == "UGANDA" ~ "Noguchi-Ghana",
+        .default = seq.lab),
+      seq.cat = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected < as_date("2025-02-01"), "Shipped for sequencing", seq.cat),
+      seq.capacity = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected < as_date("2025-02-01"), "No sequencing capacity", seq.capacity))
 
 
   return(lab_data_man)

--- a/R/dr.lab.functions.R
+++ b/R/dr.lab.functions.R
@@ -685,13 +685,13 @@ get_lab_locs <- function(lab_locs_path = NULL, use_edav = TRUE) {
   lab.locs.edited <- lab.locs |>
     dplyr::filter(!is.na(country)) |>
     dplyr::mutate(seq.capacity = stringr::str_to_lower(seq.capacity)) |>
-    dplyr::mutate(`wgs.lab*` = stringr::str_replace_all(`wgs.lab*`, "- ", "-"),
+    dplyr::mutate(`wgs.lab` = stringr::str_replace_all(`wgs.lab`, "- ", "-"),
                   seq.lab = stringr::str_replace_all(seq.lab, "- ", "-"),
                   culture.itd.lab = stringr::str_replace_all(culture.itd.lab, "- ", "-")) |>
-    dplyr::mutate(`wgs.lab*` = dplyr::case_when(
+    dplyr::mutate(`wgs.lab` = dplyr::case_when(
       country == "OCCUPIED PALESTINIAN TERRITORY, INCLUDING EAST JERUSALEM" ~ "Unknown",
-      `wgs.lab*` %in% c("-", NA) ~ "Unknown",
-      .default = `wgs.lab*`)) |>
+      `wgs.lab` %in% c("-", NA) ~ "Unknown",
+      .default = `wgs.lab`)) |>
     dplyr::mutate(culture.itd.lab = dplyr::case_when(
       country == "OCCUPIED PALESTINIAN TERRITORY, INCLUDING EAST JERUSALEM" ~ "Jordan",
       culture.itd.lab %in% c("-", NA) ~ "Unknown",

--- a/R/dr.lab.functions.R
+++ b/R/dr.lab.functions.R
@@ -1216,11 +1216,11 @@ clean_lab_data <- function(lab_data, start_date, end_date,
   #list of labs that sent samples to CDC for sequencing prior to February 2025, Nigeria and Uganda started doing their own sequencing.
   #Adding in redundancy for Nigeria in case lines above get deleted, lab locs file gets changed
   lab_data_man <- lab_data |>
-    mutate(seq.lab = case_when(DateStoolCollected < as_date("2025-02-01") & culture.itd.lab %in% c("Cameroon","KEMRI-Kenya","IBADAN-Nigeria","Ibadan-Nigeria","Nigeria","Senegal","Ethiopia","Oman/Jordan") ~ "CDC-Atlanta",
-                               DateStoolCollected < as_date("2025-02-01") & country == "UGANDA" ~ "Noguchi-Ghana",
-                               .default = seq.lab),
-           seq.cat = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected < as_date("2025-02-01"), "Shipped for sequencing", seq.cat),
-           seq.capacity = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected < as_date("2025-02-01"), "No sequencing capacity", seq.capacity))
+    dplyr::mutate(seq.lab = dplyr::case_when(DateStoolCollected < as_date("2025-02-01") & culture.itd.lab %in% c("Cameroon","KEMRI-Kenya","IBADAN-Nigeria","Ibadan-Nigeria","Nigeria","Senegal","Ethiopia","Oman/Jordan") ~ "CDC-Atlanta",
+                                             DateStoolCollected < as_date("2025-02-01") & country == "UGANDA" ~ "Noguchi-Ghana",
+                                             .default = seq.lab),
+                  seq.cat = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected < as_date("2025-02-01"), "Shipped for sequencing", seq.cat),
+                  seq.capacity = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected < as_date("2025-02-01"), "No sequencing capacity", seq.capacity))
 
 
   return(lab_data_man)

--- a/R/dr.lab.functions.R
+++ b/R/dr.lab.functions.R
@@ -1213,24 +1213,15 @@ clean_lab_data <- function(lab_data, start_date, end_date,
     lab_data <- add_rolling_years(lab_data, start_date, end_date, "CaseDate")
   }
 
-  # Add lab cleaning step to correct lab data
+  #list of labs that sent samples to CDC for sequencing prior to February 2025, Nigeria and Uganda started doing their own sequencing.
+  #Adding in redundancy for Nigeria in case lines above get deleted, lab locs file gets changed
   lab_data_man <- lab_data |>
-  mutate(seq.lab = case_when(
-    seq.lab == "CDC-Atlanta" & DateStoolCollected >= as_date("2025-02-01") & culture.itd.lab == "Cameroon" ~ "NICD-South Africa",
-    seq.lab == "CDC-Atlanta" & DateStoolCollected >= as_date("2025-02-01") & culture.itd.lab == "ETHIOPIA/ KEMRI-Kenya" ~ "UVRI-Uganda",
-    seq.lab == "CDC-Atlanta" & DateStoolCollected >= as_date("2025-02-01") & culture.itd.lab %in% c("Ibadan-Nigeria, Maiduguri-Nigeria", "Nigeria") ~ "Ibadan-Nigeria",
-    seq.lab == "CDC-Atlanta" & DateStoolCollected >= as_date("2025-02-01") & culture.itd.lab == "KEMRI-Kenya" ~ "UVRI-Uganda",
-    country == "UGANDA" & DateStoolCollected >= as_date("2025-02-01") ~ "UVRI-Uganda",
-    seq.lab == "CDC-Atlanta" & DateStoolCollected >= as_date("2025-02-01") & culture.itd.lab == "Senegal" ~ "NICD-South Africa",
-    seq.lab == "CDC-Atlanta" & DateStoolCollected >= as_date("2025-02-01") & culture.itd.lab == "Varied (KEMRI-Kenya/ Oman/ Jordan)" ~ "Varied (UVRI/ Oman/ Jordan)",
-    .default = seq.lab
-  )) |>
-  mutate(seq.cat = case_when(
-    DateStoolCollected >= as_date("2025-02-01") & culture.itd.lab %in% c("Ibadan-Nigeria, Maiduguri-Nigeria", "Nigeria") & seq.lab == "Ibadan-Nigeria" ~ "Not shipped for sequencing",
-    country == "UGANDA" & DateStoolCollected >= as_date("2025-02-01") ~ "Not shipped for sequencing",
-    .default = seq.cat
-  )) |>
-  mutate(seq.capacity = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected >= as_date("2025-02-01"), "Sequencing capacity", seq.capacity))
+    mutate(seq.lab = case_when(DateStoolCollected< as_date("2025-02-01") & culture.itd.lab %in% c("Cameroon","KEMRI-Kenya","IBADAN-Nigeria","Ibadan-Nigeria","Nigeria","Senegal","Ethiopia","Oman/Jordan")~"CDC-Atlanta",
+                               DateStoolCollected< as_date("2025-02-01") & country=="UGANDA"~"Noguchi-Ghana",
+                               .default = seq.lab),
+           seq.cat = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected < as_date("2025-02-01"), "Shipped for sequencing", seq.cat),
+           seq.capacity = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected < as_date("2025-02-01"), "No sequencing capacity", seq.capacity))
+
 
   return(lab_data_man)
 }

--- a/R/dr.lab.functions.R
+++ b/R/dr.lab.functions.R
@@ -1216,8 +1216,8 @@ clean_lab_data <- function(lab_data, start_date, end_date,
   #list of labs that sent samples to CDC for sequencing prior to February 2025, Nigeria and Uganda started doing their own sequencing.
   #Adding in redundancy for Nigeria in case lines above get deleted, lab locs file gets changed
   lab_data_man <- lab_data |>
-    mutate(seq.lab = case_when(DateStoolCollected< as_date("2025-02-01") & culture.itd.lab %in% c("Cameroon","KEMRI-Kenya","IBADAN-Nigeria","Ibadan-Nigeria","Nigeria","Senegal","Ethiopia","Oman/Jordan")~"CDC-Atlanta",
-                               DateStoolCollected< as_date("2025-02-01") & country=="UGANDA"~"Noguchi-Ghana",
+    mutate(seq.lab = case_when(DateStoolCollected < as_date("2025-02-01") & culture.itd.lab %in% c("Cameroon","KEMRI-Kenya","IBADAN-Nigeria","Ibadan-Nigeria","Nigeria","Senegal","Ethiopia","Oman/Jordan") ~ "CDC-Atlanta",
+                               DateStoolCollected < as_date("2025-02-01") & country == "UGANDA" ~ "Noguchi-Ghana",
                                .default = seq.lab),
            seq.cat = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected < as_date("2025-02-01"), "Shipped for sequencing", seq.cat),
            seq.capacity = if_else(country %in% c("NIGERIA", "UGANDA") & DateStoolCollected < as_date("2025-02-01"), "No sequencing capacity", seq.capacity))

--- a/R/kpi.table.functions.R
+++ b/R/kpi.table.functions.R
@@ -159,8 +159,8 @@ generate_pos_timeliness <- function(raw_data, start_date, end_date,
   #list of labs that sent samples to CDC for sequencing prior to February 2025, Nigeria and Uganda started doing their own sequencing.
   #Adding in redundancy for Nigeria in case lines above get deleted, lab locs file gets changed
   pos <- pos |>
-    mutate(seq.lab = case_when(dateonset< as_date("2025-02-01") & culture.itd.lab %in% c("Cameroon","KEMRI-Kenya","IBADAN-Nigeria","Ibadan-Nigeria","Nigeria","Senegal","Ethiopia","Oman/Jordan")~"CDC-Atlanta",
-                               dateonset< as_date("2025-02-01") & place.admin.0=="UGANDA"~"Noguchi-Ghana",
+    mutate(seq.lab = case_when(dateonset < as_date("2025-02-01") & culture.itd.lab %in% c("Cameroon","KEMRI-Kenya","IBADAN-Nigeria","Ibadan-Nigeria","Nigeria","Senegal","Ethiopia","Oman/Jordan") ~ "CDC-Atlanta",
+                               dateonset < as_date("2025-02-01") & place.admin.0 == "UGANDA" ~ "Noguchi-Ghana",
                                .default = seq.lab),
            seq.cat = if_else(place.admin.0 %in% c("NIGERIA", "UGANDA") & dateonset < as_date("2025-02-01"), "Shipped for sequencing", seq.cat),
            seq.capacity = if_else(place.admin.0 %in% c("NIGERIA", "UGANDA") & dateonset < as_date("2025-02-01"), "no", seq.capacity))

--- a/R/kpi.table.functions.R
+++ b/R/kpi.table.functions.R
@@ -85,10 +85,6 @@ add_seq_capacity <- function(df, ctry_col = "ctry", lab_locs = NULL) {
       by = setNames("country", ctry_col)
     )
 
-  df <- df |>
-    dplyr::mutate(seq.capacity = dplyr::if_else(!!dplyr::sym(ctry_col) == "NEPAL", "no",
-                                                seq.capacity))
-
   cli::cli_process_done()
   return(df)
 }

--- a/R/kpi.table.functions.R
+++ b/R/kpi.table.functions.R
@@ -160,23 +160,14 @@ generate_pos_timeliness <- function(raw_data, start_date, end_date,
 
   # Manual edit based on changes to the sequencing lab list in Feb 2025
   # There is no collection date, so will use dateonset to classify
+  #list of labs that sent samples to CDC for sequencing prior to February 2025, Nigeria and Uganda started doing their own sequencing.
+  #Adding in redundancy for Nigeria in case lines above get deleted, lab locs file gets changed
   pos <- pos |>
-    mutate(seq.lab = case_when(
-    seq.lab == "CDC-Atlanta" & dateonset >= as_date("2025-02-01") & culture.itd.lab == "Cameroon" ~ "NICD-South Africa",
-    seq.lab == "CDC-Atlanta" & dateonset >= as_date("2025-02-01") & culture.itd.lab == "ETHIOPIA/ KEMRI-Kenya" ~ "UVRI-Uganda",
-    seq.lab == "CDC-Atlanta" & dateonset >= as_date("2025-02-01") & culture.itd.lab %in% c("Ibadan-Nigeria, Maiduguri-Nigeria", "Nigeria") ~ "Ibadan-Nigeria",
-    seq.lab == "CDC-Atlanta" & dateonset >= as_date("2025-02-01") & culture.itd.lab == "KEMRI-Kenya" ~ "UVRI-Uganda",
-    place.admin.0 == "UGANDA" & dateonset >= as_date("2025-02-01") ~ "UVRI-Uganda",
-    seq.lab == "CDC-Atlanta" & dateonset >= as_date("2025-02-01") & culture.itd.lab == "Senegal" ~ "NICD-South Africa",
-    seq.lab == "CDC-Atlanta" & dateonset >= as_date("2025-02-01") & culture.itd.lab == "Varied (KEMRI-Kenya/ Oman/ Jordan)" ~ "Varied (UVRI/ Oman/ Jordan)",
-    .default = seq.lab
-  )) |>
-  mutate(seq.cat = case_when(
-    dateonset >= as_date("2025-02-01") & culture.itd.lab %in% c("Ibadan-Nigeria, Maiduguri-Nigeria", "Nigeria") & seq.lab == "Ibadan-Nigeria" ~ "Not shipped for sequencing",
-    place.admin.0 == "UGANDA" & dateonset >= as_date("2025-02-01") ~ "Not shipped for sequencing",
-    .default = seq.cat
-  )) |>
-  mutate(seq.capacity = if_else(place.admin.0 %in% c("NIGERIA", "UGANDA") & dateonset >= as_date("2025-02-01"), "yes", seq.capacity))
+    mutate(seq.lab = case_when(dateonset< as_date("2025-02-01") & culture.itd.lab %in% c("Cameroon","KEMRI-Kenya","IBADAN-Nigeria","Ibadan-Nigeria","Nigeria","Senegal","Ethiopia","Oman/Jordan")~"CDC-Atlanta",
+                               dateonset< as_date("2025-02-01") & place.admin.0=="UGANDA"~"Noguchi-Ghana",
+                               .default = seq.lab),
+           seq.cat = if_else(place.admin.0 %in% c("NIGERIA", "UGANDA") & dateonset < as_date("2025-02-01"), "Shipped for sequencing", seq.cat),
+           seq.capacity = if_else(place.admin.0 %in% c("NIGERIA", "UGANDA") & dateonset < as_date("2025-02-01"), "no", seq.capacity))
 
   pos_summary <- pos |>
     dplyr::mutate(

--- a/R/sirfunctions-package.R
+++ b/R/sirfunctions-package.R
@@ -224,7 +224,7 @@ utils::globalVariables(c(
   "sg_priority_level", "SG Priority Level", "site_age",  "stool_collection_date",  "stool_denom",
   "stool_label",  "t1",  "t2",  "t3",  "t4",  "t5",  "timely_cat",  "timely_det",  "timely_isolation",
   "timely_itd",  "timely_itdres_seqres",  "timely_seqres",  "timely_seqship",
-  "timely_ship",  "timely_wpv_vdpv_detections",  "wgs.lab*",  "who_region",  "whoregion",
+  "timely_ship",  "timely_wpv_vdpv_detections",  "wgs.lab",  "who_region",  "whoregion",
   "wild_vdpv",  "wpv_vdpv_detections",  "y",  "year_label",  "year_num",  "year_number",
 
   "GUIDs", "adm_level", "cases", "cg_label",


### PR DESCRIPTION
This updates lab cleaning code based on new lab locations file as of July 2026.

testing code is attached to the PR (was unable to attach an .R file so it's a .txt sorry!). Requires the new lab loc CSV file. I tested the following functions which use either the lab data, lab locs file, or both:

get_lab_locs()
clean_lab_data()
generate_pos_timeliness()
generate_kpi_lab_timeliness()*
generate_timely_det_violin()
generate_timely_ship_violin()*

All other functions that use lab data call one of these functions.

*needed to test on the code within the function itself, because there is no ability to pass a non-EDAV lab locs file. Consider enhancing these functions in the future with this feature.

generate_timely_ship_violin() also contains an unrelated error on line 948 where it is passing "place.admin.0" when the data file has "ctry"

[test_new_package.txt](https://github.com/user-attachments/files/30276626/test_new_package.txt)

